### PR TITLE
Multiple devfile registries

### DIFF
--- a/src/app/get-started/get-started.controller.ts
+++ b/src/app/get-started/get-started.controller.ts
@@ -151,19 +151,19 @@ export class GetStartedController {
       this.$log.error(message);
       return;
     }
-    return this.devfileRegistry.fetchDevfiles(this.devfileRegistryUrl).then((devfiles: Array<IDevfileMetaData>) => {
-      this.devfiles = devfiles.map(devfile => {
-        if (!devfile.icon.startsWith('http')) {
-          devfile.icon = this.devfileRegistryUrl + devfile.icon;
-        }
-        return devfile;
+
+    this.isLoading = true;
+    return this.devfileRegistry.fetchDevfiles(this.devfileRegistryUrl)
+      .then(devfiles => {
+        this.devfiles = devfiles;
+        this.toolbarProps.devfiles = devfiles;
+      }, error => {
+        const message = 'Failed to load devfiles meta list.';
+        this.cheNotification.showError(message);
+        this.$log.error(message, error);
+      }).finally(() => {
+        this.isLoading = false;
       });
-      this.toolbarProps.devfiles = this.devfiles;
-    }, (error: any) => {
-      const message = 'Failed to load devfiles meta list.';
-      this.cheNotification.showError(message);
-      this.$log.error(message, error);
-    });
   }
 
 }

--- a/src/app/get-started/sample-card/sample-card.html
+++ b/src/app/get-started/sample-card/sample-card.html
@@ -14,6 +14,9 @@
 <div class="pf-c-card pf-m-hoverable pf-m-compact pf-m-selectable get-started-template" tabindex="-1">
   <div class="pf-c-card__head">
     <img ng-if="devfile.icon" src="{{devfile.icon}}"/>
+    <div ng-if="!devfile.icon" class="blank-icon">
+      <div class="chefont cheico-type-blank"></div>
+    </div>
   </div>
   <div class="pf-c-card__header pf-c-title pf-m-md">
     <b>{{devfile.displayName}}</b>

--- a/src/app/get-started/sample-card/sample-card.styl
+++ b/src/app/get-started/sample-card/sample-card.styl
@@ -3,3 +3,13 @@
 
   img
     max-height 64px
+
+  .blank-icon
+    font-size 64px
+    width 64px
+    line-height 64px
+    text-align center
+    filter grayscale(100%) opacity(50%)
+
+    .chefont.cheico-type-blank
+      width 100%

--- a/src/app/stacks/list-stacks/list-stacks.controller.ts
+++ b/src/app/stacks/list-stacks/list-stacks.controller.ts
@@ -81,21 +81,39 @@ export class ListStacksController {
   }
 
   loadDevfiles(): void {
-    this.isLoading = true;
-    this.devfileRegistry.fetchDevfiles(this.devfileRegistryUrl).then((data: Array<IDevfileMetaData>) => {
-      this.cheListHelper.setList(data.map(devfileMetaData => {
-        if (!devfileMetaData.icon.startsWith('http')) {
-          devfileMetaData.icon = this.devfileRegistryUrl + devfileMetaData.icon;
-        }
-        return devfileMetaData;
-      }), 'displayName');
-    }, (error: any) => {
-      const message = 'Failed to load devfiles meta list.';
+    if (!this.devfileRegistryUrl) {
+      const message = 'Failed to load the devfile registry URL.';
       this.cheNotification.showError(message);
-      this.$log.error(message, error);
-    }).finally(() => {
-      this.isLoading = false;
-    });
+      this.$log.error(message);
+      return;
+    }
+
+    const urls = this.devfileRegistryUrl.split(" ");
+    let promises = [];
+    this.isLoading = true;
+
+    for (const url of urls) {
+      promises.push(this.devfileRegistry.fetchDevfiles(url).then((devfiles: Array<IDevfileMetaData>) => {
+        this.cheListHelper.setList(devfiles.map(devfileMetaData => {
+        if (devfiles && devfiles.length > 0) {
+          devfiles.forEach((devfile)=> {
+            // Set the origin url as the location
+            devfile.location = url;
+            if (!devfile.icon.startsWith('http')) {
+              devfile.icon = url + devfile.icon;
+            }
+          }
+        );
+        }
+      }), 'displayName');
+      }, (error: any) => {
+        const message = 'Failed to load devfiles meta list.';
+        this.cheNotification.showError(message);
+        this.$log.error(message, error);
+      }).finally(() => {
+        this.isLoading = false;
+      }));
+    }
   }
 
   onSearchChanged(searchStr: string): void {

--- a/src/app/stacks/list-stacks/list-stacks.styl
+++ b/src/app/stacks/list-stacks/list-stacks.styl
@@ -17,6 +17,9 @@
     div
       width 42px
 
+    .chefont.cheico-type-blank
+      width 100%
+
   che-editor
     width 100%
     margin-bottom 15px

--- a/src/app/stacks/stacks-config.ts
+++ b/src/app/stacks/stacks-config.ts
@@ -64,8 +64,8 @@ export class StacksConfig {
                 if (!devfileMetaData) {
                   return $q.reject();
                 }
-                return devfileRegistry.fetchDevfile(location, selfLink).then(() => {
-                  const devfileContent = devfileRegistry.getDevfile(location, selfLink);
+                return devfileRegistry.fetchDevfile(devfileMetaData.location, selfLink).then(() => {
+                  const devfileContent = devfileRegistry.getDevfile(devfileMetaData.location, selfLink);
                   return <IStackInitData>{ devfileMetaData, devfileContent };
                 });
               });

--- a/src/app/workspaces/create-workspace/ready-to-go-stacks/devfile-selector/devfile-selector.controller.ts
+++ b/src/app/workspaces/create-workspace/ready-to-go-stacks/devfile-selector/devfile-selector.controller.ts
@@ -49,29 +49,15 @@ export class DevfileSelectorController {
   }
 
   loadDevfiles(): void {
-    let location = this.cheWorkspace.getWorkspaceSettings().cheWorkspaceDevfileRegistryUrl;
-    const urls = location.split(" ");
-    let promises = [];
-
-    for (const url of urls) {
-      promises.push(this.devfileRegistry.fetchDevfiles(url).then((data: Array<IDevfileMetaData>) => {
-        if (data && data.length > 0) {
-          data.forEach((devfile)=> {
-            // Set the origin url as the location
-            devfile.location = url;
-            if (!devfile.icon.startsWith('http')) {
-              devfile.icon = url + devfile.icon;
-            }
-            this.devfiles.push(devfile);
-          });
+    this.cheWorkspace.fetchWorkspaceSettings()
+      .then(settings => settings.cheWorkspaceDevfileRegistryUrl)
+      .then(urls => this.devfileRegistry.fetchDevfiles(urls))
+      .then(devfiles => {
+        this.devfiles = devfiles;
+        if (this.devfiles && this.devfiles.length > 0) {
+          this.devfileOnClick(this.devfiles[0]);
         }
-      }));
-    }
-    Promise.all(promises).then(() => {
-      if (this.devfiles && this.devfiles.length > 0) {
-        this.devfileOnClick(this.devfiles[0]);
-      }
-    });
+      });
   }
 
   devfileOnClick(devfile: any): void {

--- a/src/app/workspaces/create-workspace/ready-to-go-stacks/devfile-selector/devfile-selector.controller.ts
+++ b/src/app/workspaces/create-workspace/ready-to-go-stacks/devfile-selector/devfile-selector.controller.ts
@@ -41,6 +41,7 @@ export class DevfileSelectorController {
     this.devfileRegistry = devfileRegistry;
     this.cheWorkspace = cheWorkspace;
     this.devfileOrderBy = 'displayName';
+    this.devfiles = [];
   }
 
   $onInit(): void {
@@ -49,14 +50,24 @@ export class DevfileSelectorController {
 
   loadDevfiles(): void {
     let location = this.cheWorkspace.getWorkspaceSettings().cheWorkspaceDevfileRegistryUrl;
-    this.devfileRegistry.fetchDevfiles(location).then((data: Array<IDevfileMetaData>) => {
-      this.devfiles = data.map(devfile => {
-        if (!devfile.icon.startsWith('http')) {
-          devfile.icon = location + devfile.icon;
-        }
-        return devfile;
-      });
+    const urls = location.split(" ");
+    let promises = [];
 
+    for (const url of urls) {
+      promises.push(this.devfileRegistry.fetchDevfiles(url).then((data: Array<IDevfileMetaData>) => {
+        if (data && data.length > 0) {
+          data.forEach((devfile)=> {
+            // Set the origin url as the location
+            devfile.location = url;
+            if (!devfile.icon.startsWith('http')) {
+              devfile.icon = url + devfile.icon;
+            }
+            this.devfiles.push(devfile);
+          });
+        }
+      }));
+    }
+    Promise.all(promises).then(() => {
       if (this.devfiles && this.devfiles.length > 0) {
         this.devfileOnClick(this.devfiles[0]);
       }

--- a/src/app/workspaces/create-workspace/ready-to-go-stacks/devfile-selector/devfile-selector.html
+++ b/src/app/workspaces/create-workspace/ready-to-go-stacks/devfile-selector/devfile-selector.html
@@ -45,9 +45,9 @@
                     <div class="devfile-selector-item-icon">
                       <img img-src="{{devfile.icon}}"
                         img-src-onload="devfileSelectorController.iconOnLoad(devfile.icon, $result)"
-                        ng-show="devfileSelectorController.showIcon(devfile.icon)===true">
+                        ng-show="devfile.icon && devfileSelectorController.showIcon(devfile.icon)===true">
                       <div class="chefont cheico-type-blank"
-                        ng-show="devfileSelectorController.showIcon(devfile.icon)===false"></div>
+                        ng-show="!!devfile.icon===false || devfileSelectorController.showIcon(devfile.icon)===false"></div>
                     </div>
                   </div>
                   <!-- Name -->

--- a/src/app/workspaces/create-workspace/ready-to-go-stacks/devfile-selector/devfile-selector.styl
+++ b/src/app/workspaces/create-workspace/ready-to-go-stacks/devfile-selector/devfile-selector.styl
@@ -1,6 +1,6 @@
 .devfile-selector
   width 100%
-  
+
   $devfile-selector-list-header-border = lighten($very-light-grey-color, 4%)
   $devfile-selector-list-header-background = lighten($very-light-grey-color, 28%)
 
@@ -72,7 +72,8 @@
       vertical-align top
 
     div
-      width 50px
+      width auto
+      font-size 32px
 
   .devfile-selector-item-components > div
     display inline-block

--- a/src/components/api/devfile-registry.factory.ts
+++ b/src/components/api/devfile-registry.factory.ts
@@ -20,6 +20,7 @@ export interface IDevfileMetaData {
   icon: string;
   links: any;
   tags: Array<string>;
+  location: string;
 }
 
 enum MemoryUnit { 'B', 'Ki', 'Mi', 'Gi' }

--- a/src/components/api/devfile-registry.factory.ts
+++ b/src/components/api/devfile-registry.factory.ts
@@ -10,8 +10,8 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 'use strict';
-import {CheKeycloak} from './che-keycloak.factory';
-import {IChangeMemoryUnit} from '../filter/change-memory-unit/change-memory-unit.filter';
+import { CheKeycloak } from './che-keycloak.factory';
+import { IChangeMemoryUnit } from '../filter/change-memory-unit/change-memory-unit.filter';
 
 export interface IDevfileMetaData {
   displayName: string;
@@ -32,14 +32,16 @@ const DEFAULT_JWTPROXY_MEMORY_LIMIT = '128Mi';// default value for che.server.se
  * @author Ann Shumilova
  */
 export class DevfileRegistry {
-  static $inject = ['$http', '$filter', 'cheKeycloak'];
-
-  /**
-   * Angular Http service.
-   */
-  private $http: ng.IHttpService;
+  static $inject = [
+    '$filter',
+    '$http',
+    '$q',
+    'cheKeycloak',
+  ];
 
   private $filter: ng.IFilterService;
+  private $http: ng.IHttpService;
+  private $q: ng.IQService;
 
   private devfilesMap: Map<string, che.IWorkspaceDevfile>;
 
@@ -52,9 +54,15 @@ export class DevfileRegistry {
   /**
    * Default constructor that is using resource
    */
-  constructor($http: ng.IHttpService, $filter: ng.IFilterService, cheKeycloak: CheKeycloak) {
-    this.$http = $http;
+  constructor(
+    $filter: ng.IFilterService,
+    $http: ng.IHttpService,
+    $q: ng.IQService,
+    cheKeycloak: CheKeycloak,
+  ) {
     this.$filter = $filter;
+    this.$http = $http;
+    this.$q = $q;
 
     this.devfilesMap = new Map<string, che.IWorkspaceDevfile>();
     this.isKeycloackPresent = cheKeycloak.isPresent();
@@ -63,24 +71,18 @@ export class DevfileRegistry {
     this.headers = { 'Authorization': undefined };
   }
 
-  fetchDevfiles(location: string): ng.IPromise<Array<IDevfileMetaData>> {
-    let promise = this.$http({
-      'method': 'GET',
-      'url': `${location}/devfiles/index.json`,
-      'headers': this.headers
-    });
-
-    return promise.then((result: any) => {
-      return result.data.map((devfileMetaData: IDevfileMetaData) => {
-        let globalMemoryLimitNumber = this.getMemoryLimit(devfileMetaData.globalMemoryLimit);
-        // TODO remove this after fixing https://github.com/eclipse/che/issues/11424
-        if (this.isKeycloackPresent) {
-          globalMemoryLimitNumber += this.jwtproxyMemoryLimitNumber;
-        }
-        devfileMetaData.globalMemoryLimit = this.$filter<IChangeMemoryUnit>('changeMemoryUnit')(globalMemoryLimitNumber, ['B','GB']);
-        return devfileMetaData;
-      });
-    });
+  /**
+   * Fetches devfiles from given registries.
+   * @param urls space separated list of urls
+   */
+  fetchDevfiles(urls: string): ng.IPromise<Array<IDevfileMetaData>> {
+    const devfilesArraysPromises = urls.split(' ').map(url => this._fetchDevfiles(url));
+    return this.$q.all(devfilesArraysPromises)
+      .then(devfilesArrays =>
+        devfilesArrays.reduce((devfiles, devfilesArray) => {
+          return devfiles.concat(devfilesArray);
+        }, [])
+      );
   }
 
   fetchDevfile(location: string, link: string): ng.IPromise<che.IWorkspaceDevfile> {
@@ -101,30 +103,23 @@ export class DevfileRegistry {
   }
 
   selfLinkToDevfileId(selfLink: string): string {
-      const regExpExecArray = /^\/devfiles\/([A-Za-z0-9_\-]+)\/devfile.yaml$/i.exec(selfLink);
-      if (regExpExecArray !== null) {
-         return regExpExecArray[1];
-      }
+    const regExpExecArray = /^\/devfiles\/([A-Za-z0-9_\-]+)\/devfile.yaml$/i.exec(selfLink);
+    if (regExpExecArray !== null) {
+      return regExpExecArray[1];
+    }
 
-      return selfLink;
+    return selfLink;
   }
 
   devfileIdToSelfLink(devfileId: string): string {
-      if (/^[A-Za-z0-9_\-]+$/i.test(devfileId)) {
-        return `/devfiles/${devfileId}/devfile.yaml`;
-      }
-
-      return devfileId;
-  }
-
-  private devfileYamlToJson(yaml: string): che.IWorkspaceDevfile {
-    try {
-      return jsyaml.load(yaml);
-    } catch (e) {
+    if (/^[A-Za-z0-9_\-]+$/i.test(devfileId)) {
+      return `/devfiles/${devfileId}/devfile.yaml`;
     }
+
+    return devfileId;
   }
 
-   /**
+  /**
    * Returns memory limit.
    * @param {string} memoryLimit
    * @returns {number}
@@ -145,4 +140,51 @@ export class DevfileRegistry {
 
     return parseInt(memoryLimitNumber, 10) * Math.pow(1024, power);
   }
+
+  private devfileYamlToJson(yaml: string): che.IWorkspaceDevfile {
+    try {
+      return jsyaml.load(yaml);
+    } catch (e) { }
+  }
+
+  private _fetchDevfiles(location: string): ng.IPromise<Array<IDevfileMetaData>> {
+    let promise = this.$http({
+      'method': 'GET',
+      'url': `${location}/devfiles/index.json`,
+      'headers': this.headers
+    });
+
+    return promise.then((result: any) => {
+      return result.data
+        .map(devfile => {
+          // set the origin url as the location
+          devfile.location = location;
+          return devfile;
+        })
+        .map(devfile => this.updateIconUrl(devfile, location))
+        .map(devfile => this.updateMemoryLimit(devfile));
+    });
+  }
+
+  private updateIconUrl(devfile: IDevfileMetaData, url: string): IDevfileMetaData {
+    if (devfile.icon && !devfile.icon.startsWith('http')) {
+      devfile.icon = url + devfile.icon;
+    }
+    return devfile;
+  }
+
+  private updateMemoryLimit(devfile: IDevfileMetaData): IDevfileMetaData {
+    let globalMemoryLimitNumber = this.getMemoryLimit(devfile.globalMemoryLimit);
+    if (globalMemoryLimitNumber === -1) {
+      return devfile;
+    }
+
+    // TODO remove this after fixing https://github.com/eclipse/che/issues/11424
+    if (this.isKeycloackPresent) {
+      globalMemoryLimitNumber += this.jwtproxyMemoryLimitNumber;
+    }
+    devfile.globalMemoryLimit = this.$filter<IChangeMemoryUnit>('changeMemoryUnit')(globalMemoryLimitNumber, ['B', 'GB']);
+    return devfile;
+  }
+
 }

--- a/src/components/api/devfile-registry.factory.ts
+++ b/src/components/api/devfile-registry.factory.ts
@@ -168,7 +168,7 @@ export class DevfileRegistry {
 
   private updateIconUrl(devfile: IDevfileMetaData, url: string): IDevfileMetaData {
     if (devfile.icon && !devfile.icon.startsWith('http')) {
-      devfile.icon = url + devfile.icon;
+      devfile.icon = new URL(devfile.icon, url).href;
     }
     return devfile;
   }

--- a/src/components/service/registry-checking.service.ts
+++ b/src/components/service/registry-checking.service.ts
@@ -55,10 +55,19 @@ export class RegistryCheckingService {
     const REGISTRY_CERTIFICATE_ERROR = `Unable to load plugins and/or devfiles. Your ${this.cheBranding.getName()} may be using a self-signed certificate. To resolve this issue, try to import the servers CA certificate into your browser, as described in <a href="${this.cheBranding.getDocs().certificate}" target="_blank">docs</a>. After importing the certificate, refresh the page.`;
 
     this.cheWorkspace.fetchWorkspaceSettings()
-      .then(settings => [
-        `${settings.cheWorkspaceDevfileRegistryUrl}/devfiles/index.json`,
-        `${settings.cheWorkspacePluginRegistryUrl}/plugins/`
-      ])
+      .then(settings => {
+        const urls = [];
+        if (settings.cheWorkspacePluginRegistryUrl) {
+          urls.push(`${settings.cheWorkspacePluginRegistryUrl}/plugins/`);
+        }
+        if (settings.cheWorkspaceDevfileRegistryUrl) {
+          // space separated list
+          settings.cheWorkspaceDevfileRegistryUrl
+            .split(' ')
+            .forEach(url => urls.push(`${url}/devfiles/index.json`));
+        }
+        return urls;
+      })
       .then(locations => this.$q.all(
         locations.map(location => this.checkPossibleCertificateIssue(location))
       ))


### PR DESCRIPTION
### What does this PR do?
This PR allows multiple devfile registries to be specified as a space separated list, for example in values.yml we can have:
```yaml
che: 
  workspace: 
    devfileRegistryUrl: "https://che-devfile-registry.openshift.io/ https://raw.githubusercontent.com/kabanero-io/codewind-templates/master/"
```
The registry location is then stored so that the devfile can be read from the correct location.

The initial implementation is taken from https://github.com/eclipse/che/pull/16390, https://github.com/eclipse/che/pull/14059

It contains only Dashboard related changes. Che Server and Che Operator changes will be made separately.

### What issues does this PR fix or reference?
Fixes https://github.com/eclipse/che/issues/13961