### PR TITLE
Fixed documentation link for Che in TLS mode

### DIFF
--- a/src/assets/branding/product.json
+++ b/src/assets/branding/product.json
@@ -29,7 +29,7 @@
     "factory": "/docs/factories-getting-started.html",
     "organization": "/docs/organizations.html",
     "converting": "/docs/che-7/converting-a-che-6-workspace-to-a-che-7-devfile/",
-    "certificate": "/docs/che-7/setup-che-in-tls-mode-with-self-signed-certificate/",
+    "certificate": "/docs/che-7/installing-che-in-tls-mode-with-self-signed-certificates/",
     "general": "/docs/che-7"
   }
 }


### PR DESCRIPTION
Signed-off-by: Oleksii Kurinnyi <okurinny@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

This PR fixes documentation link for installing Che in TLS mode with self-signed certificates

### What issues does this PR fix or reference?

N/A