### PR TITLE
Added detection of unsupported browser.

### DIFF
--- a/src/app/index.module.ts
+++ b/src/app/index.module.ts
@@ -36,6 +36,7 @@ import {ProfileConfig} from './profile/profile-config';
 import {ResourceFetcherService} from '../components/service/resource-fetcher/resource-fetcher.service';
 import {CheBranding} from '../components/branding/che-branding';
 import { RegistryCheckingService } from '../components/service/registry-checking.service';
+import { DetectSupportedBrowserService } from '../components/service/browser-detect';
 
 // init module
 const initModule = angular.module('userDashboard', ['ngAnimate', 'ngCookies', 'ngTouch', 'ngSanitize', 'ngResource', 'ngRoute',
@@ -307,6 +308,7 @@ initModule.run([
   '$routeParams',
   '$timeout',
   'cheUIElementsInjectorService',
+  'detectSupportedBrowserService',
   'registryCheckingService',
   'resourceFetcherService',
   'routeHistory',
@@ -319,6 +321,7 @@ initModule.run([
     $routeParams: ng.route.IRouteParamsService,
     $timeout: ng.ITimeoutService,
     cheUIElementsInjectorService: CheUIElementsInjectorService,
+    detectSupportedBrowserService: DetectSupportedBrowserService,
     registryCheckingService: RegistryCheckingService,
     resourceFetcherService: ResourceFetcherService,
     routeHistory: RouteHistory,
@@ -335,6 +338,7 @@ initModule.run([
     registryCheckingService;
     resourceFetcherService;
     routeHistory;
+    detectSupportedBrowserService;
     /* tslint:enable */
 
     $rootScope.$on('$viewContentLoaded', () => {

--- a/src/components/service/browser-detect.ts
+++ b/src/components/service/browser-detect.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2015-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+'use strict';
+
+import { GlobalWarningBannerService } from '../../../target/dist/components/service/global-warning-banner.service';
+
+const UNSUPPORTED_BROWSER_WARNING = `You're using a web browser we don't support. Please consider using Chrome or Firefox instead.`;
+
+export class DetectSupportedBrowserService {
+
+  static $inject = [
+    'globalWarningBannerService',
+  ];
+
+  constructor(
+    globalWarningBannerService: GlobalWarningBannerService,
+  ) {
+    if (this.isSupported === false) {
+      globalWarningBannerService.addMessage(UNSUPPORTED_BROWSER_WARNING);
+    }
+  }
+
+  get isChrome(): boolean {
+    // @ts-ignore
+    return !!window.chrome && (!!window.chrome.webstore || !!window.chrome.runtime);
+  }
+
+  get isFirefox(): boolean {
+    // @ts-ignore
+    return typeof InstallTrigger !== 'undefined';
+  }
+
+  get isSupported(): boolean {
+    return this.isChrome || this.isFirefox;
+  }
+
+}

--- a/src/components/service/service-config.ts
+++ b/src/components/service/service-config.ts
@@ -18,6 +18,7 @@ import {ResourcesService} from './resources-service/resources-service';
 import { ResourceFetcherService } from './resource-fetcher/resource-fetcher.service';
 import { GlobalWarningBannerService } from './global-warning-banner.service';
 import { RegistryCheckingService } from './registry-checking.service';
+import { DetectSupportedBrowserService } from './browser-detect';
 
 export class ServiceConfig {
 
@@ -30,5 +31,6 @@ export class ServiceConfig {
     register.service('resourceFetcherService', ResourceFetcherService);
     register.service('globalWarningBannerService', GlobalWarningBannerService);
     register.service('registryCheckingService', RegistryCheckingService);
+    register.service('detectSupportedBrowserService', DetectSupportedBrowserService);
   }
 }


### PR DESCRIPTION
Signed-off-by: Oleksii Kurinnyi <okurinny@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

This PR adds a service that detects user's browser and warns them if that browser is not supported.

*Screenshot from Safari*

<img width="663" alt="Screenshot 2020-05-14 at 12 46 43" src="https://user-images.githubusercontent.com/16220722/81919877-10c8d980-95e1-11ea-8504-666b28ba653a.png">



### What issues does this PR fix or reference?

resolves https://github.com/eclipse/che/issues/16840
