### PR TITLE
Fix wording of warning for unsupported browser.

### DIFF
--- a/src/components/service/browser-detect.ts
+++ b/src/components/service/browser-detect.ts
@@ -13,7 +13,7 @@
 
 import { GlobalWarningBannerService } from './global-warning-banner.service';
 
-const UNSUPPORTED_BROWSER_WARNING = `You're using a web browser we don't support. Please consider using Chrome or Firefox instead.`;
+const UNSUPPORTED_BROWSER_WARNING = `You're using a web browser we don't support. Consider using Chrome or Firefox instead.`;
 
 export class DetectSupportedBrowserService {
 


### PR DESCRIPTION
Signed-off-by: Oleksii Kurinnyi <okurinny@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

This PR slightly changes the wording of message for unsupported browsers, so now user will see: 
**«You're using a web browser we don't support. Consider using Chrome or Firefox instead.»**
