### PR TITLE
Hide organizations UI on dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,13 +258,9 @@ For example,
 }
 ```
 
-In the case of disabling the `"factories"`, `load factory` routing won't be disabled because it is using for creating a new workspace from the devfile URL.
+**Note**: Menu entries also may be disabled by default in [branding.constant.ts](https://github.com/eclipse/che-dashboard/blob/master/src/components/branding/branding.constant.ts#L112-L122). In order to force enable such entries they need to be listed in `"configuration.menu.enabled"` field.
 
-For example,
-
-```
-https://che.openshift.io/f?url=https://raw.githubusercontent.com/eclipse/che/master/devfile.yaml 
-```
+In the case of disabling the `"factories"`, `load factory` routing won't be disabled because it is used for creating a new workspace from the devfile URL. For example, `https://che.openshift.io/f?url=https://raw.githubusercontent.com/eclipse/che/master/devfile.yaml` .
 
 The `"configuration.prefetch"` section allows to define resources that UD should pre-fetch. This section consists of following optional fields:
 

--- a/src/app/navbar/navbar.controller.ts
+++ b/src/app/navbar/navbar.controller.ts
@@ -161,18 +161,20 @@ export class CheNavBarController {
    * Update data.
    */
   updateData(): void {
-    const organization = this.cheAPI.getOrganization();
-    organization.fetchOrganizations().then(() => {
-      this.organizations = organization.getOrganizations();
-      const user = this.cheAPI.getUser().getUser();
-      organization.fetchOrganizationByName(user.name)
-        .catch(() => {
-          // fetch unhandled rejection
-        })
-        .finally(() => {
-          this.hasPersonalAccount = angular.isDefined(organization.getOrganizationByName(user.name));
-        });
-    });
+    if (this.showOrganizationsItem()) {
+      const organization = this.cheAPI.getOrganization();
+      organization.fetchOrganizations().then(() => {
+        this.organizations = organization.getOrganizations();
+        const user = this.cheAPI.getUser().getUser();
+        organization.fetchOrganizationByName(user.name)
+          .catch(() => {
+            // fetch unhandled rejection
+          })
+          .finally(() => {
+            this.hasPersonalAccount = angular.isDefined(organization.getOrganizationByName(user.name));
+          });
+      });
+    }
   }
 
   /**
@@ -221,8 +223,16 @@ export class CheNavBarController {
     return rootOrganizations.length;
   }
 
-  showMenuItem(menuItem: che.ConfigurableMenuItem | string): boolean {
+  showMenuItem(menuItem: che.ConfigurableMenuItem): boolean {
     return this.cheDashboardConfigurationService.allowedMenuItem(menuItem);
+  }
+
+  showOrganizationsItem(): boolean {
+    return this.showMenuItem('organizations');
+  }
+
+  showAdministrationSection(): boolean {
+    return this.showOrganizationsItem() && (this.userServices.hasInstallationManagerService || this.userServices.hasAdminUserService);
   }
 
   /**

--- a/src/app/navbar/navbar.html
+++ b/src/app/navbar/navbar.html
@@ -93,7 +93,7 @@
             </md-list-item>
             <!-- Organizations -->
             <md-list-item flex class="navbar-subsection-item"
-                          ng-if="navbarController.showMenuItem('organizations') &&
+                          ng-if="navbarController.showOrganizationsItem() &&
                           navbarController.isPermissionServiceAvailable &&
                           !navbarController.userServices.hasInstallationManagerService &&
                           !navbarController.hasPersonalAccount">
@@ -112,7 +112,7 @@
         </section>
       </div>
       <div class="admin-navbar-menu"
-           ng-if="navbarController.userServices.hasInstallationManagerService || navbarController.userServices.hasAdminUserService">
+           ng-if="navbarController.showAdministrationSection()">
         <section class="left-sidebar-menu" layout="column" layout-align="start start">
           <div class="navbar-section navbar-section-title"
                flex layout="row" layout-align="start start">
@@ -131,7 +131,7 @@
               </md-button>
             </md-list-item>
             <md-list-item flex class="navbar-subsection-item"
-                          ng-if="navbarController.userServices.hasInstallationManagerService">
+                          ng-if="navbarController.showOrganizationsItem() && navbarController.userServices.hasInstallationManagerService">
               <md-button nav-bar-selected flex che-reload-href
                          href="{{navbarController.menuItemUrl.organizations}}" layout-align="left">
                 <div class="navbar-item" layout="row" layout-align="start center" id="organizations-item">

--- a/src/app/organizations/organizations-config.service.spec.ts
+++ b/src/app/organizations/organizations-config.service.spec.ts
@@ -14,6 +14,7 @@ import { CheAPIBuilder } from '../../components/api/builder/che-api-builder.fact
 import { CheHttpBackend } from '../../components/api/test/che-http-backend';
 import { OrganizationsConfigServiceMock } from './organizations-config.service.mock';
 import { CheBranding } from '../../components/branding/che-branding';
+import { CheDashboardConfigurationService } from '../../components/branding/che-dashboard-configuration.service';
 
 /* tslint:disable:no-empty */
 describe('OrganizationsConfig >', () => {
@@ -47,12 +48,16 @@ describe('OrganizationsConfig >', () => {
     _$route_: ng.route.IRouteService,
     _$rootScope_: ng.IRootScopeService,
     _cheHttpBackend_: CheHttpBackend,
-    _cheAPIBuilder_: CheAPIBuilder
+    _cheAPIBuilder_: CheAPIBuilder,
+    cheDashboardConfigurationService: CheDashboardConfigurationService,
   ) => {
     $injector = _$injector_;
     $route = _$route_;
     $rootScope = _$rootScope_;
     $httpBackend = _cheHttpBackend_.getHttpBackend();
+
+    // enable all menu items and routes if any
+    cheDashboardConfigurationService.allowedMenuItem = () => true;
 
     setPath = path => {
       _$location_.path(path);

--- a/src/app/teams/navbar-teams/navbar-teams.controller.ts
+++ b/src/app/teams/navbar-teams/navbar-teams.controller.ts
@@ -11,6 +11,8 @@
  */
 'use strict';
 
+import { CheDashboardConfigurationService } from '../../../components/branding/che-dashboard-configuration.service';
+
 /**
  * @ngdoc controller
  * @name teams.navbar.controller:NavbarTeamsController
@@ -19,22 +21,33 @@
  */
 export class NavbarTeamsController {
 
-  static $inject = ['cheTeam'];
+  static $inject = [
+    'cheDashboardConfigurationService',
+    'cheTeam',
+  ];
 
   /**
    * Team API interaction.
    */
   private cheTeam: che.api.ICheTeam;
 
+  private cheDashboardConfigurationService: CheDashboardConfigurationService;
+
   /**
    * Default constructor
    */
-  constructor(cheTeam: che.api.ICheTeam) {
+  constructor(
+    cheDashboardConfigurationService: CheDashboardConfigurationService,
+    cheTeam: che.api.ICheTeam,
+  ) {
+    this.cheDashboardConfigurationService = cheDashboardConfigurationService;
     this.cheTeam = cheTeam;
   }
 
   $onInit(): void {
-    this.fetchTeams();
+    if (this.cheDashboardConfigurationService.allowedMenuItem('organizations')) {
+      this.fetchTeams();
+    }
   }
 
   /**

--- a/src/app/workspaces/workspace-details/workspace-details.service.ts
+++ b/src/app/workspaces/workspace-details/workspace-details.service.ts
@@ -187,7 +187,8 @@ export class WorkspaceDetailsService {
     this.sections = [];
 
     cheService.fetchServices().finally(() => {
-      const sharingEnabled = this.cheDashboardConfigurationService.enabledFeature(TogglableFeature.WORKSPACE_SHARING);
+      const sharingEnabled = this.cheDashboardConfigurationService.allowedMenuItem('organizations')
+        && this.cheDashboardConfigurationService.enabledFeature(TogglableFeature.WORKSPACE_SHARING);
       const permissionServiceAvailable = cheService.isServiceAvailable(chePermissions.getPermissionsServicePath());
       if (sharingEnabled && permissionServiceAvailable) {
         this.addPage('Share', '<share-workspace></share-workspace>', 'icon-ic_folder_shared_24px');

--- a/src/components/api/che-team.factory.ts
+++ b/src/components/api/che-team.factory.ts
@@ -157,12 +157,7 @@ export class CheTeam implements che.api.ICheTeam {
       }
     });
 
-    return defer.promise.then(() => {
-      this.fetchTeamsDefer.resolve();
-    }, (error: any) => {
-      this.fetchTeamsDefer.reject();
-      return this.$q.reject(error);
-    });
+    return defer.promise;
   }
 
   /**

--- a/src/components/api/che-team.factory.ts
+++ b/src/components/api/che-team.factory.ts
@@ -11,8 +11,9 @@
  */
 'use strict';
 
-import {CheTeamRoles} from './che-team-roles';
-import {CheTeamEventsManager} from './che-team-events-manager.factory';
+import { CheTeamEventsManager } from './che-team-events-manager.factory';
+import { CheTeamRoles } from './che-team-roles';
+import { CheDashboardConfigurationService } from '../branding/che-dashboard-configuration.service';
 
 interface ITeamsResource<T> extends ng.resource.IResourceClass<T> {
   findTeam(data: { teamName: string }): ng.resource.IResource<T>;
@@ -25,7 +26,18 @@ interface ITeamsResource<T> extends ng.resource.IResourceClass<T> {
  */
 export class CheTeam implements che.api.ICheTeam {
 
-  static $inject = ['$resource', '$q', 'lodash', 'cheNamespaceRegistry', 'cheUser', 'cheOrganization', 'cheTeamEventsManager', 'cheResourcesDistribution', 'resourcesService'];
+  static $inject = [
+    '$q',
+    '$resource',
+    'cheDashboardConfigurationService',
+    'cheNamespaceRegistry',
+    'cheOrganization',
+    'cheResourcesDistribution',
+    'cheTeamEventsManager',
+    'cheUser',
+    'lodash',
+    'resourcesService',
+  ];
 
   /**
    * Angular Resource service.
@@ -70,24 +82,34 @@ export class CheTeam implements che.api.ICheTeam {
    */
   private cheResourcesDistribution: che.api.ICheResourcesDistribution;
 
+  private cheDashboardConfigurationService: CheDashboardConfigurationService;
+
   private resourceLimits: che.resource.ICheResourceLimits;
 
   /**
    * Default constructor that is using resource
    */
-  constructor($resource: ng.resource.IResourceService,
-              $q: ng.IQService, lodash: any, cheNamespaceRegistry: any, cheUser: any,
-              cheOrganization: che.api.ICheOrganization, cheTeamEventsManager: CheTeamEventsManager, cheResourcesDistribution: che.api.ICheResourcesDistribution,
-              resourcesService: che.service.IResourcesService) {
-    this.$resource = $resource;
+  constructor(
+    $q: ng.IQService,
+    $resource: ng.resource.IResourceService,
+    cheDashboardConfigurationService: CheDashboardConfigurationService,
+    cheNamespaceRegistry: any,
+    cheOrganization: che.api.ICheOrganization,
+    cheResourcesDistribution: che.api.ICheResourcesDistribution,
+    cheTeamEventsManager: CheTeamEventsManager,
+    cheUser: any,
+    lodash: any,
+    resourcesService: che.service.IResourcesService,
+  ) {
     this.$q = $q;
-    this.lodash = lodash;
+    this.$resource = $resource;
     this.cheNamespaceRegistry = cheNamespaceRegistry;
-    this.cheUser = cheUser;
-    this.teamEventsManager = cheTeamEventsManager;
     this.cheOrganization = cheOrganization;
     this.cheResourcesDistribution = cheResourcesDistribution;
+    this.cheUser = cheUser;
+    this.lodash = lodash;
     this.resourceLimits = resourcesService.getResourceLimits();
+    this.teamEventsManager = cheTeamEventsManager;
 
     this.remoteTeamAPI = <ITeamsResource<any>>$resource('/api/organization', {}, {
       findTeam: {method: 'GET', url: '/api/organization/find?name=:teamName'}
@@ -109,7 +131,9 @@ export class CheTeam implements che.api.ICheTeam {
       this.fetchTeams();
     });
 
-    this.fetchTeams(); // this resolves `cheNamespaceRegistry.fetchNamespaces()` as well
+    if (cheDashboardConfigurationService.allowedMenuItem('organizations')) {
+      this.fetchTeams(); // this resolves `cheNamespaceRegistry.fetchNamespaces()` as well
+    }
   }
 
   /**

--- a/src/components/branding/branding.constant.ts
+++ b/src/components/branding/branding.constant.ts
@@ -60,6 +60,7 @@ export type IBrandingFooter = {
 export type IBrandingConfiguration = {
   menu: {
     disabled: che.ConfigurableMenuItem[];
+    enabled?: che.ConfigurableMenuItem[];
   },
   prefetch: {
     cheCDN?: string;
@@ -111,7 +112,9 @@ export const BRANDING_DEFAULT: IBranding = {
   },
   configuration: {
     menu: {
-      disabled: []
+      disabled: [
+        "organizations"
+      ],
     },
     features: {
       disabled: []

--- a/src/components/branding/che-dashboard-configuration.service.ts
+++ b/src/components/branding/che-dashboard-configuration.service.ts
@@ -41,9 +41,9 @@ export class CheDashboardConfigurationService {
     this.cheBranding = cheBranding;
   }
 
-  allowedMenuItem(menuItem: che.ConfigurableMenuItem | string): boolean {
-    const disabledItems = this.cheBranding.getConfiguration().menu.disabled;
-    return (disabledItems as string[]).indexOf(menuItem) === -1;
+  allowedMenuItem(menuItem: che.ConfigurableMenuItem): boolean {
+    const disabledItems = this.getDisabledItems();
+    return (disabledItems).indexOf(menuItem) === -1;
   }
 
   allowRoutes(menuItem: che.ConfigurableMenuItem): ng.IPromise<void> {
@@ -96,6 +96,15 @@ export class CheDashboardConfigurationService {
       };
     }
     return links;
+  }
+
+  private getDisabledItems(): che.ConfigurableMenuItem[] {
+    const menu = this.cheBranding.getConfiguration().menu;
+    const disabled = menu.disabled || [];
+    const forceEnabled = menu.enabled || [];
+
+    const disabledItems = disabled.filter(item => forceEnabled.indexOf(item) === -1);
+    return disabledItems;
   }
 
 }


### PR DESCRIPTION
Signed-off-by: Oleksii Kurinnyi <okurinny@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

This PR hides `organizations` and `teams` UI on dashboard and prevents fetching organizations on dashboard start.

### What issues does this PR fix or reference?

https://github.com/eclipse/che/issues/16973

