### PR TITLE
Fix workspace name validation on Custom Workspace page

### DIFF
--- a/src/app/get-started/custom-workspace-tab/workspace-name-row/workspace-name-row.controller.ts
+++ b/src/app/get-started/custom-workspace-tab/workspace-name-row/workspace-name-row.controller.ts
@@ -13,21 +13,24 @@
 
 import { IWorkspaceNameRowComponentBindings, IWorkspaceNameRowComponentInputBindings } from './workspace-name-row.component';
 import { IChePfTextInputProperties } from '../../../../components/che-pf-widget/text-input/che-pf-text-input.directive';
-import { RandomSvc } from '../../../../components/utils/random.service';
 
 type OnChangesObject = {
   [key in keyof IWorkspaceNameRowComponentInputBindings]: ng.IChangesObject<IWorkspaceNameRowComponentInputBindings[key]>;
 };
 
+const MIN_LENGTH = 3;
+const MAX_LENGTH = 100;
 const DEFAULT_PLACEHOLDER = 'Enter a workspace name';
 const ERROR_REQUIRED_VALUE = 'A value is required.';
-const ERROR_PATTERN_MISMATCH = 'The name should not contain special characters like space, dollar, etc., and should start and end only with digits, latin letters or underscores.';
+const ERROR_MIN_LENGTH = `The name has to be at least ${MIN_LENGTH} characters long.`;
+const ERROR_MAX_LENGTH = `The name is too long. The maximum length is ${MAX_LENGTH} characters.`;
+const ERROR_PATTERN_MISMATCH = 'The name can contain digits, latin letters, underscores and it should not contain special characters like space, dollar, etc. It should start and end only with digit or latin letter.';
 
 export class WorkspaceNameRowController implements ng.IController, IWorkspaceNameRowComponentBindings {
 
   static $inject = [
     '$element',
-    'randomSvc',
+    '$scope',
   ];
 
   // component bindings
@@ -42,23 +45,34 @@ export class WorkspaceNameRowController implements ng.IController, IWorkspaceNam
 
   // injected services
   private $element: ng.IAugmentedJQuery;
-  private randomSvc: RandomSvc;
+  private $scope: ng.IScope;
 
   constructor(
     $element: ng.IAugmentedJQuery,
-    randomSvc: RandomSvc,
+    $scope: ng.IScope,
   ) {
     this.$element = $element;
-    this.randomSvc = randomSvc;
 
+    const patternMaxLength = MAX_LENGTH - 2;
     this.workspaceNameInput = {
       config: {
         name: 'workspaceName',
         placeHolder: DEFAULT_PLACEHOLDER,
-        pattern: '^[A-Za-z0-9][A-Za-z0-9_\\-\\.]+[A-Za-z0-9]$',
+        pattern: `^(?:[a-zA-Z0-9][-_.a-zA-Z0-9]{1,${patternMaxLength}}[a-zA-Z0-9])?$`,
+        minLength: MIN_LENGTH,
+        maxLength: MAX_LENGTH,
       },
       onChange: name => this.onChanged(name),
     };
+
+    // workaround to trigger validation after changing workspace name in devfile editor
+    $scope.$watch(() => {
+      return $element.find(`input[name="${this.workspaceNameInput.config.name}"]`).val();
+    }, (newName) => {
+      if (newName) {
+        this.onValidated(true);
+      }
+    });
   }
 
   $onChanges(onChangesObj: OnChangesObject): void {
@@ -82,19 +96,46 @@ export class WorkspaceNameRowController implements ng.IController, IWorkspaceNam
     }
   }
 
+  private findInput(): HTMLInputElement | undefined {
+    const input = this.$element.find('input');
+    if (!input[0]) {
+      return;
+    }
+    return input[0] as HTMLInputElement;
+  }
+
   private onChanged(name: string): void {
     this.onValidated();
     this.onChange({ '$name': name });
   }
 
-  private onValidated(): void {
-    const input = this.$element.find('input');
-    const validity = (input[0] as HTMLInputElement).validity;
+  private onValidated(doCheckValidity = false): void {
+    const jqInput = this.$element.find('input');
+
+    const input = this.findInput();
+    if (!input) {
+      return;
+    }
+
+    let tooShort = false;
+    let tooLong = false;
+    if (doCheckValidity) {
+      input.checkValidity();
+
+      // workaround to show correct validation message
+      if (jqInput.val().toString().length < MIN_LENGTH) {
+        tooShort = true;
+      } else if (jqInput.val().toString().length > MAX_LENGTH) {
+        tooLong = true;
+      }
+    }
+
+    const validity = input.validity;
 
     // hide error messages if valid
     if (validity.valid) {
       delete this.errorMessage;
-      input.removeAttr('aria-invalid');
+      jqInput.removeAttr('aria-invalid');
       return;
     }
 
@@ -102,11 +143,19 @@ export class WorkspaceNameRowController implements ng.IController, IWorkspaceNam
       // show 'required' error message
       this.errorMessage = ERROR_REQUIRED_VALUE;
     }
-    if (validity.patternMismatch) {
+    else if (validity.tooShort || tooShort) {
+      // show 'minlength' error message
+      this.errorMessage = ERROR_MIN_LENGTH;
+    }
+    else if (validity.tooLong || tooLong) {
+      // show 'maxlength' error message
+      this.errorMessage = ERROR_MAX_LENGTH;
+    }
+    else if (validity.patternMismatch) {
       // show 'pattern' error message
       this.errorMessage = ERROR_PATTERN_MISMATCH;
     }
-    input.attr('aria-invalid', 'true');
+    jqInput.attr('aria-invalid', 'true');
   }
 
 }

--- a/src/components/che-pf-widget/text-input/che-pf-text-input.directive.ts
+++ b/src/components/che-pf-widget/text-input/che-pf-text-input.directive.ts
@@ -21,6 +21,8 @@ export interface IChePfTextInputProperties extends IChePfInputProperties {
     pattern?: string;
     placeHolder?: string;
     labelName?: string;
+    minLength?: number;
+    maxLength?: number;
   };
   onChange: ($value: string) => void;
 }
@@ -32,6 +34,8 @@ interface IChePfTextInputDirectiveBindings extends IChePfInputBindings {
     pattern?: string;
     placeHolder?: string;
     labelName?: string;
+    minLength?: string;
+    maxLength?: string;
   };
   onChange: (eventObj: { $value: string }) => void;
 }

--- a/src/components/che-pf-widget/text-input/che-pf-text-input.html
+++ b/src/components/che-pf-widget/text-input/che-pf-text-input.html
@@ -15,5 +15,7 @@
     ng-model="value"
     ng-change="onChange({$value: value})"
     ng-attr-pattern={{config.pattern}}
+    ng-attr-minlength={{config.minLength}}
+    ng-attr-maxlength={{config.maxLength}}
     ng-attr-placeholder="{{config.placeHolder}}" />
 </div>


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

- updates validation message when workspace name doesn't match provided pattern;
- adds validations for min and max length of workspace name;
- trigger validation after changing workspace name in devfile editor.

<details>
 <summary>Animated demo</summary>

![Screen Recording 2020-05-29 at 14 47 20 2020-05-29 14_59_50](https://user-images.githubusercontent.com/16220722/83257456-174c7900-a1bd-11ea-97e3-539a259c3d0a.gif)

</details>


### What issues does this PR fix or reference?

https://github.com/eclipse/che/issues/16303

