### PR TITLE
Fix stack-editor styles

### DIFF
--- a/src/app/stacks/stack-details/stack.styl
+++ b/src/app/stacks/stack-details/stack.styl
@@ -14,14 +14,11 @@
 .stack-details-input
   margin 0 8px
 
-.stack-editor, .stack-editor-footer
-  min-width 500px
-  max-width 1000px
-
 .stack-editor
+  position relative
+  height 500px
   width 100%
   margin 0 0 20px 8px
 
 .stack-editor .monaco-editor
   border 1px solid $list-separator-color
-  min-height 500px


### PR DESCRIPTION
Signed-off-by: Oleksii Orel <oorel@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Fix stack-editor styles.

before
![Screenshot from 2020-06-11 15-46-02](https://user-images.githubusercontent.com/6310786/84386859-bed49d00-abfa-11ea-95c5-3176db63b856.png)

with these changes
![Screenshot from 2020-06-11 15-36-37](https://user-images.githubusercontent.com/6310786/84386233-a2843080-abf9-11ea-8687-e52be1490a16.png)
