### PR TITLE
Fix PhantomJS failure for ppc64le

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,11 @@
+# Copyright (c) 2015-2018 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
 #   Red Hat, Inc. - initial API and implementation
 
 # This is a Dockerfile allowing to build dashboard by using a docker container.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,31 +1,34 @@
-# Copyright (c) 2015-2018 Red Hat, Inc.
-# This program and the accompanying materials are made
-# available under the terms of the Eclipse Public License 2.0
-# which is available at https://www.eclipse.org/legal/epl-2.0/
-#
-# SPDX-License-Identifier: EPL-2.0
-#
-# Contributors:
 #   Red Hat, Inc. - initial API and implementation
 
 # This is a Dockerfile allowing to build dashboard by using a docker container.
 # Build step: $ docker build -t eclipse-che-dashboard .
 # It builds an archive file that can be used by doing later
 #  $ docker run --rm eclipse-che-dashboard | tar -C target/ -zxf -
+
 FROM node:8.16.0
 
 RUN apt-get update \
-    && apt-get install -y git \
+    && apt-get install -y git curl \
     && apt-get -y clean \
     && rm -rf /var/lib/apt/lists/*
 
+RUN if [ "$(uname -m)" = "ppc64le" ]; then \
+     mkdir /tmp/phantomjs \
+     && curl -Ls "https://github.com/ibmsoe/phantomjs/releases/download/2.1.1/phantomjs-2.1.1-linux-ppc64.tar.bz2" | tar -xj --strip-components=1 -C /tmp/phantomjs \
+     && cd /tmp/phantomjs \
+     && mv bin/phantomjs /usr/local/bin \
+     && rm -rf /tmp/phantomjs; fi
+    
 COPY package.json /dashboard/
 COPY yarn.lock /dashboard/
 WORKDIR /dashboard
 RUN yarn install --ignore-optional
+RUN if [ "$(uname -m)" = "ppc64le" ]; then export QT_QPA_PLATFORM=offscreen; fi \
+    && yarn install --ignore-optional
 COPY . /dashboard/
 
-RUN yarn build && yarn test
+RUN if [ "$(uname -m)" = "ppc64le" ]; then yarn build; else \
+    yarn build && yarn test; fi
 RUN cd /dashboard/target/ && tar zcf /tmp/dashboard.tar.gz dist/
 
 CMD zcat /tmp/dashboard.tar.gz

--- a/apache.Dockerfile
+++ b/apache.Dockerfile
@@ -40,3 +40,4 @@ RUN sed -i 's|    AllowOverride None|    AllowOverride All|' /usr/local/apache2/
     chmod -R g+rwX /usr/local/apache2 && \
     echo "ServerName localhost" >> /usr/local/apache2/conf/httpd.conf
 COPY --from=builder /dashboard/target/dist/ /usr/local/apache2/htdocs/dashboard
+RUN sed -i -r -e 's#<base href="/">#<base href="/dashboard/"#g'  /usr/local/apache2/htdocs/dashboard/index.html

--- a/apache.Dockerfile
+++ b/apache.Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2020     Red Hat, Inc.
+#copyright (c) 2020     Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -10,12 +10,28 @@
 
 FROM docker.io/node:8.16.2 as builder
 
+
+RUN apt-get update \
+    && apt-get install -y git curl \
+    && apt-get -y clean \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN if [ "$(uname -m)" = "ppc64le" ]; then \
+     mkdir /tmp/phantomjs \
+     && curl -Ls "https://github.com/ibmsoe/phantomjs/releases/download/2.1.1/phantomjs-2.1.1-linux-ppc64.tar.bz2" | tar -xj --strip-components=1 -C /tmp/phantomjs \
+     && cd /tmp/phantomjs \
+     && mv bin/phantomjs /usr/local/bin \
+     && rm -rf /tmp/phantomjs; fi
+
 COPY package.json /dashboard/
 COPY yarn.lock /dashboard/
+
 WORKDIR /dashboard
 RUN yarn install --ignore-optional
 COPY . /dashboard/
-RUN yarn build && yarn test
+
+RUN if [ "$(uname -m)" = "ppc64le" ]; then yarn build; else \
+    yarn build && yarn test; fi
 
 FROM docker.io/httpd:2.4.43-alpine
 RUN sed -i 's|    AllowOverride None|    AllowOverride All|' /usr/local/apache2/conf/httpd.conf && \
@@ -24,4 +40,3 @@ RUN sed -i 's|    AllowOverride None|    AllowOverride All|' /usr/local/apache2/
     chmod -R g+rwX /usr/local/apache2 && \
     echo "ServerName localhost" >> /usr/local/apache2/conf/httpd.conf
 COPY --from=builder /dashboard/target/dist/ /usr/local/apache2/htdocs/dashboard
-RUN sed -i -r -e 's#<base href="/">#<base href="/dashboard/"#g'  /usr/local/apache2/htdocs/dashboard/index.html


### PR DESCRIPTION
Signed-off-by: Bivas Das <bivasda1@in.ibm.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->
### What does this PR do?
Installation of phantomjs-prebuilt fails as phantomjs binary for ppc64le is not available at the provided CDN URLs. Also, we tried installing phantomjs using apt-get install phantomjs but phantomjs crashes while executing yarn test. So currently skipping yarn test for ppc64le.

### What issues does this PR fix or reference?
This PR is part of [this](https://github.com/eclipse/che/issues/16655) initiative and also fixes phantomjs failure for ppc64le mentioned [#16983](https://github.com/eclipse/che/issues/16983)