### PR TITLE
Fix updating devfile icons in case of single host

### DIFF
--- a/src/components/api/devfile-registry.factory.ts
+++ b/src/components/api/devfile-registry.factory.ts
@@ -168,7 +168,14 @@ export class DevfileRegistry {
 
   private updateIconUrl(devfile: IDevfileMetaData, url: string): IDevfileMetaData {
     if (devfile.icon && !devfile.icon.startsWith('http')) {
-      devfile.icon = new URL(devfile.icon, url).href;
+      if (!url.endsWith('/')) {
+        url += "/"
+      }
+      if (devfile.icon.startsWith('/')) {
+        devfile.icon = url + devfile.icon.substring(1)
+      } else {
+        devfile.icon = url + devfile.icon
+      }
     }
     return devfile;
   }


### PR DESCRIPTION
Signed-off-by: Anatoliy Bazko <abazko@redhat.com>

### What does this PR do?
In case of single host the devfile registry url looks like `https://domain/devfile-registry`
Using `URL` leads to image href `https://domain/images/someimage.svg` but not to `https://domain/devfile-registry/images/someimage.svg`

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/14564

#### Release Notes
N/A

#### Docs PR
N/A