### PR TITLE
Fix build in Github Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,7 +36,7 @@ jobs:
     - name: "Docker build with cache"
       uses: nick-invision/retry@v1
       with:
-        timeout_minutes: 20
+        timeout_minutes: 40
         max_attempts: 5
         retry_wait_seconds: 60
         command: docker buildx build --platform linux/amd64,linux/s390x --cache-from="type=registry,ref=${CACHE_IMAGE_FULL}" --cache-to="type=registry,ref=${CACHE_IMAGE_FULL},mode=max" -t ${IMAGE_FULL}  -f apache.Dockerfile --push .


### PR DESCRIPTION
Signed-off-by: Prabhav Thali <Prabhav.Thali1@ibm.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Increases timeout_minutes from 20 to 40 as build fails on `yarn build` for s390x.
Timeout is increased to 40 mins as `yarn build` takes approximately 34-35 mins for s390x in github actions. 

### What issues does this PR fix or reference?
Fixes the build failure in https://github.com/eclipse/che-dashboard/runs/893425657?check_suite_focus=true

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
