### PR TITLE
Add documentation link for storage types

### DIFF
--- a/src/app/get-started/get-started-tab/toolbar/get-started-toolbar.controller.ts
+++ b/src/app/get-started/get-started-tab/toolbar/get-started-toolbar.controller.ts
@@ -32,8 +32,8 @@ export class GetStartedToolbarController implements IGetStartedToolbarComponentB
   // component bindings
   ephemeralMode: boolean;
   devfiles: IDevfileMetaData[];
-  onFilterChange: (eventObj: {$filtered: IDevfileMetaData[]}) => void;
-  onStorageTypeChange: (eventObj: {$storageType: StorageType}) => void;
+  onFilterChange: (eventObj: { $filtered: IDevfileMetaData[] }) => void;
+  onStorageTypeChange: (eventObj: { $storageType: StorageType }) => void;
 
   filterInput: IChePfTextInputProperties;
   filterResultsCount: number;
@@ -93,7 +93,7 @@ export class GetStartedToolbarController implements IGetStartedToolbarComponentB
     }
     this.filterResultsCount = this.filteredDevfiles.length;
 
-    this.onFilterChange({$filtered: this.filteredDevfiles});
+    this.onFilterChange({ $filtered: this.filteredDevfiles });
   }
 
   private storageTypeChange(ephemeralOn: boolean): void {

--- a/src/app/get-started/get-started-tab/toolbar/get-started-toolbar.controller.ts
+++ b/src/app/get-started/get-started-tab/toolbar/get-started-toolbar.controller.ts
@@ -16,6 +16,7 @@ import { IChePfTextInputProperties } from '../../../../components/che-pf-widget/
 import { IChePfSwitchProperties } from '../../../../components/che-pf-widget/switch/che-pf-switch.directive';
 import { IGetStartedToolbarComponentInputBindings, IGetStartedToolbarComponentBindings } from './get-started-toolbar.component';
 import { StorageType } from '../../../../components/service/storage-type.service';
+import { CheBranding } from '../../../../components/branding/che-branding';
 
 type OnChangeObject = {
   [key in keyof IGetStartedToolbarComponentInputBindings]: ng.IChangesObject<IGetStartedToolbarComponentInputBindings[key]>;
@@ -24,7 +25,8 @@ type OnChangeObject = {
 export class GetStartedToolbarController implements IGetStartedToolbarComponentBindings {
 
   static $inject = [
-    '$filter'
+    '$filter',
+    'cheBranding',
   ];
 
   // component bindings
@@ -38,14 +40,18 @@ export class GetStartedToolbarController implements IGetStartedToolbarComponentB
   tmpStorage: IChePfSwitchProperties;
   filteredDevfiles: Array<IDevfileMetaData> = [];
   selectedDevfile: IDevfileMetaData | undefined;
+  tooltipContent: string;
 
   // injected services
   private $filter: ng.IFilterService;
+  private cheBranding: CheBranding;
 
   constructor(
     $filter: ng.IFilterService,
+    cheBranding: CheBranding,
   ) {
     this.$filter = $filter;
+    this.cheBranding = cheBranding;
 
     this.filterInput = {
       config: {
@@ -60,8 +66,12 @@ export class GetStartedToolbarController implements IGetStartedToolbarComponentB
         name: 'temporary-storage-switch'
       },
       onChange: ephemeralOn => this.storageTypeChange(ephemeralOn)
-
     };
+
+    this.tooltipContent = `Temporary Storage allows for faster I/O but may have
+      limited storage and is not persistent.
+      <br/>
+      <a target="_blank" href="${this.cheBranding.getDocs().storageTypes}">Open documentation page</a>`;
   }
 
   $onChanges(onChangesObj: OnChangeObject): void {

--- a/src/app/get-started/get-started-tab/toolbar/get-started-toolbar.html
+++ b/src/app/get-started/get-started-tab/toolbar/get-started-toolbar.html
@@ -19,8 +19,11 @@
           Temporary Storage
         </span>
         <span class="temporary-storage-tooltip"
-          uib-tooltip-html="'Temporary Storage allows for faster I/O but may have limited storage and is not persistent.'"
-          tooltip-trigger="mouseenter" tabindex="-1" tooltip-append-to-body="true">
+          uib-tooltip-html="'{{getStartedToolbarController.tooltipContent}}'"
+          tooltip-trigger="mouseenter"
+          tooltip-popup-close-delay="2000"
+          tabindex="-1"
+          tooltip-append-to-body="true">
           <i class="fa fa-question-circle" aria-hidden="true"></i>
         </span>
         <!-- temporary storage toggle end -->

--- a/src/assets/branding/product.json
+++ b/src/assets/branding/product.json
@@ -29,6 +29,7 @@
     "organization": "https://www.eclipse.org/che/docs/organizations.html",
     "converting": "https://www.eclipse.org/che/docs/che-7/converting-a-che-6-workspace-to-a-che-7-devfile/",
     "certificate": "https://www.eclipse.org/che/docs/che-7/installing-che-in-tls-mode-with-self-signed-certificates/#using-che-with-tls_installing-che-in-tls-mode-with-self-signed-certificates",
-    "general": "https://www.eclipse.org/che/docs/che-7"
+    "general": "https://www.eclipse.org/che/docs/che-7",
+    "storageTypes": "https://www.eclipse.org/che/docs/che-7/using-diffrent-type-of-storage/"
   }
 }

--- a/src/assets/branding/product.json
+++ b/src/assets/branding/product.json
@@ -30,6 +30,6 @@
     "converting": "https://www.eclipse.org/che/docs/che-7/converting-a-che-6-workspace-to-a-che-7-devfile/",
     "certificate": "https://www.eclipse.org/che/docs/che-7/installing-che-in-tls-mode-with-self-signed-certificates/#using-che-with-tls_installing-che-in-tls-mode-with-self-signed-certificates",
     "general": "https://www.eclipse.org/che/docs/che-7",
-    "storageTypes": "https://www.eclipse.org/che/docs/che-7/using-diffrent-type-of-storage/"
+    "storageTypes": "https://www.eclipse.org/che/docs/che-7/using-different-type-of-storage/"
   }
 }

--- a/src/components/branding/branding.constant.ts
+++ b/src/components/branding/branding.constant.ts
@@ -43,6 +43,7 @@ export type IBrandingDocs = {
   converting: string,
   certificate: string,
   faq?: string,
+  storageTypes: string,
 }
 
 export type IBrandingWorkspace = {
@@ -106,7 +107,8 @@ export const BRANDING_DEFAULT: IBranding = {
     organization: 'https://www.eclipse.org/che/docs/organizations.html',
     converting: 'https://www.eclipse.org/che/docs/che-7/converting-a-che-6-workspace-to-a-che-7-devfile/',
     certificate: 'https://www.eclipse.org/che/docs/che-7/installing-che-in-tls-mode-with-self-signed-certificates/#using-che-with-tls_installing-che-in-tls-mode-with-self-signed-certificates',
-    general: 'https://www.eclipse.org/che/docs/che-7'
+    general: 'https://www.eclipse.org/che/docs/che-7',
+    storageTypes: "https://www.eclipse.org/che/docs/che-7/using-diffrent-type-of-storage/",
   },
   configuration: {
     menu: {

--- a/src/components/branding/branding.constant.ts
+++ b/src/components/branding/branding.constant.ts
@@ -108,7 +108,7 @@ export const BRANDING_DEFAULT: IBranding = {
     converting: 'https://www.eclipse.org/che/docs/che-7/converting-a-che-6-workspace-to-a-che-7-devfile/',
     certificate: 'https://www.eclipse.org/che/docs/che-7/installing-che-in-tls-mode-with-self-signed-certificates/#using-che-with-tls_installing-che-in-tls-mode-with-self-signed-certificates',
     general: 'https://www.eclipse.org/che/docs/che-7',
-    storageTypes: "https://www.eclipse.org/che/docs/che-7/using-diffrent-type-of-storage/",
+    storageTypes: "https://www.eclipse.org/che/docs/che-7/using-different-type-of-storage/",
   },
   configuration: {
     menu: {

--- a/src/components/service/storage-type.service.ts
+++ b/src/components/service/storage-type.service.ts
@@ -12,7 +12,7 @@
 'use strict';
 
 import { CheWorkspace } from '../api/workspace/che-workspace.factory';
-import ng = require('angular');
+import { CheBranding } from '../branding/che-branding';
 
 export enum StorageType {
   'async' = 'Asynchronous',
@@ -23,16 +23,21 @@ export enum StorageType {
 export class StorageTypeService {
 
   static $inject = [
+    'cheBranding',
     'cheWorkspace',
   ];
 
-  private readyPromise: ng.IPromise<void>;
+  private cheBranding: CheBranding;
   private cheWorkspace: CheWorkspace;
+
+  private readyPromise: ng.IPromise<void>;
   private settings: che.IWorkspaceSettings;
 
   constructor(
+    cheBranding: CheBranding,
     cheWorkspace: CheWorkspace,
   ) {
+    this.cheBranding = cheBranding;
     this.cheWorkspace = cheWorkspace;
 
     this.readyPromise = this.cheWorkspace.fetchWorkspaceSettings()
@@ -97,6 +102,9 @@ export class StorageTypeService {
           </p>`
         : ''
         }
+        <p>
+          <a target="_blank" href="${this.cheBranding.getDocs().storageTypes}">Open documentation page</a>
+        </p>
       </div>
     `;
   }


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

This PR add links to the documentation page about storage types wherever storage type switcher or selector is used within the UD.

<details>
<summary>Screenshots</summary>

![Screenshot 2020-07-28 at 14 52 58](https://user-images.githubusercontent.com/16220722/88662587-d4d2ea00-d0e2-11ea-853b-b5505698b7c2.png)

![Screenshot 2020-07-28 at 14 59 35](https://user-images.githubusercontent.com/16220722/88662684-fc29b700-d0e2-11ea-9931-c3db9d27589d.png)

![Screenshot 2020-07-28 at 14 57 13](https://user-images.githubusercontent.com/16220722/88662605-dbf9f800-d0e2-11ea-87a1-a077be3e5c12.png)



</details>


### What issues does this PR fix or reference?

resolves https://github.com/eclipse/che/issues/17498

