### PR TITLE
Show delete button on the workspace list

### DIFF
--- a/src/app/workspaces/list-workspaces/list-workspaces.html
+++ b/src/app/workspaces/list-workspaces/list-workspaces.html
@@ -27,10 +27,11 @@
                      che-add-button-title="Add Workspace"
                      che-add-button-href="#/getstarted?tab=customWorkspace"
                      che-delete-button-title="Delete"
+                     che-delete-button-disable="listWorkspacesCtrl.cheListHelper.isNoItemSelected"
                      che-on-delete="listWorkspacesCtrl.deleteSelectedWorkspaces()"
                      che-filter-values="listWorkspacesCtrl.namespaceLabels"
                      che-on-filter-changed="listWorkspacesCtrl.onFilterChanged"
-                     che-hide-delete="listWorkspacesCtrl.cheListHelper.isNoItemSelected"
+                     che-hide-delete="listWorkspacesCtrl.userWorkspaces.length === 0"
                      che-hide-header="listWorkspacesCtrl.cheListHelper.visibleItemsNumber === 0">
       <div flex="100"
            layout="row"


### PR DESCRIPTION
### What does this PR do?

Shows 'Delete' button on "Workspaces" page if workspaces are available.
It is hidden until checkbox is checked.  Che beginners can't figure out they can remove their workspaces.

After applied this PR, "Delete" button is shown and disbabled if workspaces are available.

![ink (7)](https://user-images.githubusercontent.com/101795/89116237-97989e80-d4cc-11ea-9947-ea659498fb2c.png)

"Delete" button is enabled if checkboxes are checked.

![Screenshot 2020-08-02 at 14 27 13](https://user-images.githubusercontent.com/101795/89116253-c44cb600-d4cc-11ea-9b1a-6e5b1b94456d.png)

"Delete" button is hidden if there is no workspace. (This behavior is same as the search box.) 

### What issues does this PR fix or reference?

None.
