### PR TITLE
Fix storage type selector update and initialization on Custom Workspace tab

### DIFF
--- a/src/app/get-started/custom-workspace-tab/custom-workspace-tab.controller.ts
+++ b/src/app/get-started/custom-workspace-tab/custom-workspace-tab.controller.ts
@@ -193,18 +193,21 @@ export class CustomWorkspaceTabController implements ng.IController {
       delete this.devfileEditorProperties.devfile;
       return;
     }
-    if (this.devfile.attributes && this.devfile.attributes.persistVolumes) {
-      const val = (this.devfile.attributes.persistVolumes === 'false');
-      if (val) {
-        if (this.devfile.attributes.asyncPersist === 'true') {
-          this.storageTypeProperties.storageType = StorageType.async;
-        } else {
-          this.storageTypeProperties.storageType = StorageType.ephemeral;
-        }
+
+    // storage type
+    const isNotPersist = this.devfile.attributes && this.devfile.attributes.persistVolumes === 'false';
+    if (isNotPersist) {
+      const isAsync = this.devfile.attributes.asyncPersist === 'true';
+      if (isAsync) {
+        this.storageTypeProperties.storageType = StorageType.async;
+      } else {
+        this.storageTypeProperties.storageType = StorageType.ephemeral;
       }
     } else {
-      this.storageTypeProperties.storageType = undefined;
+      this.storageTypeProperties.storageType = StorageType.persistent;
     }
+
+    // workspace name
     if (this.devfile.metadata && this.devfile.metadata.name) {
       this.workspaceName = this.devfile.metadata.name;
       this.workspaceNameProperties.name = this.devfile.metadata.name;

--- a/src/app/get-started/custom-workspace-tab/storage-type-row/storage-type-row.controller.ts
+++ b/src/app/get-started/custom-workspace-tab/storage-type-row/storage-type-row.controller.ts
@@ -44,6 +44,8 @@ export class StorageTypeRowController implements ng.IController, IStorageTypeRow
 
   private initPromise: ng.IPromise<void>;
   private preferredStorageType: StorageType;
+  // indicates that next onChange event should be skipped
+  private skipNextChange: boolean;
 
   constructor(
     chePfModalService: ChePfModalService,
@@ -60,13 +62,15 @@ export class StorageTypeRowController implements ng.IController, IStorageTypeRow
       .then(() => {
         const items = this.storageTypeService.getAvailableTypes()
           .map(type => StorageType[type]);
+        this.preferredStorageType = StorageType[this.storageTypeService.getPreferredType()];
         this.storageSelect = {
           config: {
             id: this.selectorId,
+            default: this.preferredStorageType,
             items,
             placeholder: 'Select a storage template'
           },
-          value: this.storageTypeService.getPreferredType(),
+          value: this.preferredStorageType,
           onSelect: storageType => this.onStorageTypeChanged(storageType),
         };
         this.isReady = true;
@@ -82,6 +86,7 @@ export class StorageTypeRowController implements ng.IController, IStorageTypeRow
         this.storageSelect.value = this.preferredStorageType;
         return;
       }
+      this.skipNextChange = true;
       this.storageSelect.value = onChangesObj.storageType.currentValue;
     });
   }
@@ -93,6 +98,10 @@ export class StorageTypeRowController implements ng.IController, IStorageTypeRow
   }
 
   onStorageTypeChanged(storageType: StorageType): void {
+    if (this.skipNextChange) {
+      this.skipNextChange = false;
+      return;
+    }
     this.onChangeStorageType({ '$storageType': storageType })
   }
 


### PR DESCRIPTION
Signed-off-by: Oleksii Kurinnyi <okurinny@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

- storage type selector gets initialized with a preferred storage type
- changing storage type attributes in the devfile editor makes storage type selector properly update its value
