### PR TITLE
Extracted inline styles from template into stylus module

### DIFF
--- a/src/app/get-started/custom-workspace-tab/custom-workspace-tab.controller.ts
+++ b/src/app/get-started/custom-workspace-tab/custom-workspace-tab.controller.ts
@@ -18,7 +18,7 @@ import { IWorkspaceNameRowBindingProperties } from './workspace-name-row/workspa
 import { IStorageTypeRowBindingProperties } from './storage-type-row/storage-type-row.component';
 import { IDevfileSelectRowBindingProperties } from './devfile-select-row/devfile-select-row.component';
 import { IDevfileEditorBindingProperties } from '../../../components/widget/devfile-editor/devfile-editor.component';
-import { StorageType } from '../../../components/service/storage-type.service';
+import { StorageType } from '../../../components/service/storage-type/storage-type.service';
 
 export class CustomWorkspaceTabController implements ng.IController {
 

--- a/src/app/get-started/custom-workspace-tab/storage-type-row/storage-type-row.component.ts
+++ b/src/app/get-started/custom-workspace-tab/storage-type-row/storage-type-row.component.ts
@@ -12,7 +12,7 @@
 'use strict';
 
 import { StorageTypeRowController } from './storage-type-row.controller';
-import { StorageType } from '../../../../components/service/storage-type.service';
+import { StorageType } from '../../../../components/service/storage-type/storage-type.service';
 
 export interface IStorageTypeRowBindingProperties {
   storageType?: StorageType;

--- a/src/app/get-started/custom-workspace-tab/storage-type-row/storage-type-row.controller.ts
+++ b/src/app/get-started/custom-workspace-tab/storage-type-row/storage-type-row.controller.ts
@@ -14,7 +14,7 @@
 import { IStorageTypeRowComponentBindings } from './storage-type-row.component';
 import { IChePfSelectProperties } from '../../../../components/che-pf-widget/select/che-pf-select-typeahead.directive';
 import { ChePfModalService } from '../../../../components/che-pf-widget/modal/che-pf-modal.service';
-import { StorageTypeService, StorageType } from '../../../../components/service/storage-type.service';
+import { StorageTypeService, StorageType } from '../../../../components/service/storage-type/storage-type.service';
 
 type OnChangesObject = {
   [key in keyof IStorageTypeRowComponentBindings]: ng.IChangesObject<IStorageTypeRowComponentBindings[key]>;

--- a/src/app/get-started/get-started-tab/get-started-tab.controller.ts
+++ b/src/app/get-started/get-started-tab/get-started-tab.controller.ts
@@ -17,7 +17,7 @@ import { DevfileRegistry, IDevfileMetaData } from '../../../components/api/devfi
 import { CheNotification } from '../../../components/notification/che-notification.factory';
 import { IChePfButtonProperties } from '../../../components/che-pf-widget/button/che-pf-button';
 import { IGetStartedToolbarBindingProperties } from './toolbar/get-started-toolbar.component';
-import { StorageType } from '../../../components/service/storage-type.service';
+import { StorageType } from '../../../components/service/storage-type/storage-type.service';
 
 
 /**

--- a/src/app/get-started/get-started-tab/toolbar/get-started-toolbar.component.ts
+++ b/src/app/get-started/get-started-tab/toolbar/get-started-toolbar.component.ts
@@ -13,7 +13,7 @@
 
 import { GetStartedToolbarController } from './get-started-toolbar.controller';
 import { IDevfileMetaData } from '../../../../components/api/devfile-registry.factory';
-import { StorageType } from '../../../../components/service/storage-type.service';
+import { StorageType } from '../../../../components/service/storage-type/storage-type.service';
 
 export interface IGetStartedToolbarBindingProperties {
   devfiles: IDevfileMetaData[];

--- a/src/app/get-started/get-started-tab/toolbar/get-started-toolbar.controller.ts
+++ b/src/app/get-started/get-started-tab/toolbar/get-started-toolbar.controller.ts
@@ -15,7 +15,7 @@ import { IDevfileMetaData } from '../../../../components/api/devfile-registry.fa
 import { IChePfTextInputProperties } from '../../../../components/che-pf-widget/text-input/che-pf-text-input.directive';
 import { IChePfSwitchProperties } from '../../../../components/che-pf-widget/switch/che-pf-switch.directive';
 import { IGetStartedToolbarComponentInputBindings, IGetStartedToolbarComponentBindings } from './get-started-toolbar.component';
-import { StorageType } from '../../../../components/service/storage-type.service';
+import { StorageType } from '../../../../components/service/storage-type/storage-type.service';
 import { CheBranding } from '../../../../components/branding/che-branding';
 
 type OnChangeObject = {

--- a/src/app/index.module.ts
+++ b/src/app/index.module.ts
@@ -37,7 +37,7 @@ import {ResourceFetcherService} from '../components/service/resource-fetcher/res
 import {CheBranding} from '../components/branding/che-branding';
 import { RegistryCheckingService } from '../components/service/registry-checking.service';
 import { DetectSupportedBrowserService } from '../components/service/browser-detect';
-import { StorageTypeService } from '../components/service/storage-type.service';
+import { StorageTypeService } from '../components/service/storage-type/storage-type.service';
 
 // init module
 const initModule = angular.module('userDashboard', ['ngAnimate', 'ngCookies', 'ngTouch', 'ngSanitize', 'ngResource', 'ngRoute',

--- a/src/app/workspaces/workspace-details/workspace-overview/workspace-details-overview.controller.ts
+++ b/src/app/workspaces/workspace-details/workspace-overview/workspace-details-overview.controller.ts
@@ -18,7 +18,7 @@ import { WorkspaceDetailsService } from '../workspace-details.service';
 import { CheKubernetesNamespace } from '../../../../components/api/che-kubernetes-namespace.factory';
 import { CheDashboardConfigurationService } from '../../../../components/branding/che-dashboard-configuration.service';
 import { TogglableFeature } from '../../../../components/branding/branding.constant';
-import { StorageTypeService, StorageType } from '../../../../components/service/storage-type.service';
+import { StorageTypeService, StorageType } from '../../../../components/service/storage-type/storage-type.service';
 
 const STARTING = WorkspaceStatus[WorkspaceStatus.STARTING];
 const RUNNING = WorkspaceStatus[WorkspaceStatus.RUNNING];

--- a/src/components/service/service-config.ts
+++ b/src/components/service/service-config.ts
@@ -19,7 +19,7 @@ import { ResourceFetcherService } from './resource-fetcher/resource-fetcher.serv
 import { GlobalWarningBannerService } from './global-warning-banner.service';
 import { RegistryCheckingService } from './registry-checking.service';
 import { DetectSupportedBrowserService } from './browser-detect';
-import { StorageTypeService } from './storage-type.service';
+import { StorageTypeService } from './storage-type/storage-type.service';
 
 export class ServiceConfig {
 

--- a/src/components/service/storage-type/storage-type.service.ts
+++ b/src/components/service/storage-type/storage-type.service.ts
@@ -11,8 +11,8 @@
  */
 'use strict';
 
-import { CheWorkspace } from '../api/workspace/che-workspace.factory';
-import { CheBranding } from '../branding/che-branding';
+import { CheWorkspace } from '../../api/workspace/che-workspace.factory';
+import { CheBranding } from '../../branding/che-branding';
 
 export enum StorageType {
   'async' = 'Asynchronous',
@@ -94,7 +94,7 @@ export class StorageTypeService {
         }
         ${ showAsync
         ? `<p>
-            <span style= "font-size: 0.8em; color: #F37943" > Experimental feature </span><br/>
+            <span class="experimental-storage-type"> Experimental feature </span><br/>
             <b>Asynchronous Storage </b>
             is combination of Ephemeral and Persistent storages.It allows for
             faster I / O and keeps your changes, it does backup the workspace on

--- a/src/components/service/storage-type/storage-type.styl
+++ b/src/components/service/storage-type/storage-type.styl
@@ -1,0 +1,3 @@
+.experimental-storage-type
+  font-size 0.8em
+  color #F37943


### PR DESCRIPTION
Signed-off-by: Oleksii Kurinnyi <okurinny@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

Inline CSS rules get removed from the template when modal box is shown. This PR extracts them into a stylus module to avoid losing correct styles.

#### Screenshots

**Before**

<img width="619" alt="Screenshot 2020-08-03 at 15 09 31" src="https://user-images.githubusercontent.com/16220722/89180994-7eaaee80-d59b-11ea-9590-cd654bca2140.png">


**After**

<img width="619" alt="Screenshot 2020-08-03 at 15 07 52" src="https://user-images.githubusercontent.com/16220722/89181022-866a9300-d59b-11ea-972a-cc263d21e106.png">

