### PR TITLE
Show errors happened during factory acceptance

### DIFF
--- a/src/app/factories/load-factory/load-factory.controller.ts
+++ b/src/app/factories/load-factory/load-factory.controller.ts
@@ -360,7 +360,8 @@ export class LoadFactoryController {
 
       const attrs = {factoryurl: `${url}${params}`};
       this.cheAPI.getWorkspace().createWorkspaceFromDevfile(undefined, undefined, devfile, attrs)
-        .then((workspace: che.IWorkspace) => defer.resolve(workspace));
+        .then((workspace: che.IWorkspace) => defer.resolve(workspace))
+        .catch(error => defer.reject(error));
     }
     defer.promise.then((workspace: che.IWorkspace) => {
       this.$timeout(() => {

--- a/src/app/factories/load-factory/load-factory.service.ts
+++ b/src/app/factories/load-factory/load-factory.service.ts
@@ -37,16 +37,8 @@ export class LoadFactoryService {
    */
   constructor (workspacesService: WorkspacesService) {
     this.workspacesService = workspacesService;
-    this.loadFactoryInProgress = false;
-    this.currentProgressStep = 0;
 
-    this.loadingSteps = [
-      {text: 'Loading factory', inProgressText: '', logs: '', hasError: false},
-      {text: 'Looking for devfile', inProgressText: '', logs: '', hasError: false},
-      {text: 'Initializing workspace', inProgressText: 'Provision workspace and associating it with the existing user', logs: '', hasError: false},
-      {text: 'Starting workspace runtime', inProgressText: 'Retrieving the stack\'s image and launching it', logs: '', hasError: false},
-      {text: 'Open IDE', inProgressText: '', logs: '', hasError: false}
-    ];
+    this.resetLoadProgress();
   }
 
   /**
@@ -102,13 +94,16 @@ export class LoadFactoryService {
    * Reset the loading progress.
    */
   resetLoadProgress(): void {
-    this.loadingSteps.forEach((step: FactoryLoadingStep) => {
-      step.logs = '';
-    step.hasError = false;
-  });
-  this.currentProgressStep = 0;
+    this.loadFactoryInProgress = false;
+    this.currentProgressStep = 0;
 
-  this.loadFactoryInProgress = false;
+    this.loadingSteps = [
+      {text: 'Loading factory', inProgressText: '', logs: '', hasError: false},
+      {text: 'Looking for devfile', inProgressText: '', logs: '', hasError: false},
+      {text: 'Initializing workspace', inProgressText: 'Provision workspace and associating it with the existing user', logs: '', hasError: false},
+      {text: 'Starting workspace runtime', inProgressText: 'Retrieving the stack\'s image and launching it', logs: '', hasError: false},
+      {text: 'Open IDE', inProgressText: '', logs: '', hasError: false}
+    ];
   }
 
   /**


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

The UD now handles the error happened during the factory acceptance and displays it on the factory loader screen.


![Screenshot 2020-08-04 at 13 04 42](https://user-images.githubusercontent.com/16220722/89281705-233c3780-d653-11ea-927b-24344d195bd5.png)

### What issues does this PR fix or reference?

fixes https://github.com/eclipse/che/issues/17502

