### PR TITLE
Fix link to self-signed certs documentation in cert error page

### DIFF
--- a/src/assets/branding/product.json
+++ b/src/assets/branding/product.json
@@ -28,7 +28,7 @@
     "factory": "https://www.eclipse.org/che/docs/factories-getting-started.html",
     "organization": "https://www.eclipse.org/che/docs/organizations.html",
     "converting": "https://www.eclipse.org/che/docs/che-7/converting-a-che-6-workspace-to-a-che-7-devfile/",
-    "certificate": "https://www.eclipse.org/che/docs/che-7/installing-che-in-tls-mode-with-self-signed-certificates/#using-che-with-tls_installing-che-in-tls-mode-with-self-signed-certificates",
+    "certificate": "https://www.eclipse.org/che/docs/che-7/importing-certificates-to-browsers/",
     "general": "https://www.eclipse.org/che/docs/che-7",
     "storageTypes": "https://www.eclipse.org/che/docs/che-7/using-different-type-of-storage/"
   }


### PR DESCRIPTION
### What does this PR do?
Fixes the link on the certificate error page, which was broken by https://github.com/eclipse/che-docs/pull/1451:

![Screenshot from 2020-08-26 15-56-06](https://user-images.githubusercontent.com/16168279/91351003-83874a80-e7b5-11ea-9ef6-c62d0bbee32e.png)

**Note: this PR depends on https://github.com/eclipse/che-docs/pull/1493**

### What issues does this PR fix or reference?
Fixes https://github.com/eclipse/che/issues/17712

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
https://github.com/eclipse/che-docs/pull/1493