### PR TITLE
Storage type improvements

### DIFF
--- a/src/app/get-started/custom-workspace-tab/storage-type-row/storage-type-row.controller.ts
+++ b/src/app/get-started/custom-workspace-tab/storage-type-row/storage-type-row.controller.ts
@@ -28,7 +28,7 @@ export class StorageTypeRowController implements ng.IController, IStorageTypeRow
   ];
 
   // component bindings
-  isReady: boolean = false;
+  storageType?: StorageType;
   onChangeStorageType: (eventObj: { '$storageType': StorageType; }) => void;
 
   // used in template
@@ -53,6 +53,18 @@ export class StorageTypeRowController implements ng.IController, IStorageTypeRow
   ) {
     this.chePfModalService = chePfModalService;
     this.storageTypeService = storageTypeService;
+
+    this.storageSelect = {
+      config: {
+        id: this.selectorId,
+        default: this.storageType || StorageType.persistent,
+        items: [StorageType.persistent],
+        placeholder: 'Select a storage template',
+        disabled: true,
+      },
+      value: this.preferredStorageType,
+      onSelect: storageType => this.onStorageTypeChanged(storageType),
+    };
   }
 
   $onInit(): void {
@@ -63,17 +75,10 @@ export class StorageTypeRowController implements ng.IController, IStorageTypeRow
         const items = this.storageTypeService.getAvailableTypes()
           .map(type => StorageType[type]);
         this.preferredStorageType = StorageType[this.storageTypeService.getPreferredType()];
-        this.storageSelect = {
-          config: {
-            id: this.selectorId,
-            default: this.preferredStorageType,
-            items,
-            placeholder: 'Select a storage template'
-          },
-          value: this.preferredStorageType,
-          onSelect: storageType => this.onStorageTypeChanged(storageType),
-        };
-        this.isReady = true;
+
+        this.storageSelect.config.default = this.preferredStorageType;
+        this.storageSelect.config.disabled = items.length === 1;
+        this.storageSelect.config.items = items;
       });
   }
 
@@ -84,6 +89,9 @@ export class StorageTypeRowController implements ng.IController, IStorageTypeRow
     this.initPromise.then(() => {
       if (onChangesObj.storageType.currentValue === undefined) {
         this.storageSelect.value = this.preferredStorageType;
+        return;
+      }
+      if (onChangesObj.storageType.currentValue === this.storageSelect.value) {
         return;
       }
       this.skipNextChange = true;

--- a/src/app/get-started/custom-workspace-tab/storage-type-row/storage-type-row.controller.ts
+++ b/src/app/get-started/custom-workspace-tab/storage-type-row/storage-type-row.controller.ts
@@ -74,7 +74,7 @@ export class StorageTypeRowController implements ng.IController, IStorageTypeRow
       .then(() => {
         const items = this.storageTypeService.getAvailableTypes()
           .map(type => StorageType[type]);
-        this.preferredStorageType = StorageType[this.storageTypeService.getPreferredType()];
+        this.preferredStorageType = this.storageTypeService.getPreferredType();
 
         this.storageSelect.config.default = this.preferredStorageType;
         this.storageSelect.config.disabled = items.length === 1;

--- a/src/app/get-started/custom-workspace-tab/storage-type-row/storage-type-row.html
+++ b/src/app/get-started/custom-workspace-tab/storage-type-row/storage-type-row.html
@@ -19,7 +19,7 @@
 
   <div class="pf-l-flex">
     <div class="pf-l-flex-item">
-      <div ng-if="ctrl.isReady"
+      <div
         class="pf-c-form__horizontal-group">
         <che-pf-select-single class="storage-type-selector" config="ctrl.storageSelect.config"
           value="ctrl.storageSelect.value" on-select="ctrl.storageSelect.onSelect($value)">

--- a/src/app/get-started/get-started-tab/get-started-tab.controller.ts
+++ b/src/app/get-started/get-started-tab/get-started-tab.controller.ts
@@ -86,6 +86,7 @@ export class GetStartedTabController {
 
       return this.storageTypeService.ready;
     }).then(() => {
+      this.storageType = this.storageTypeService.getPreferredType();
       this.toolbarProps.storageType = this.storageTypeService.getPreferredType();
       this.toolbarProps.storageTypeDisabled = this.storageTypeService.getAvailableTypes().length === 1;
 

--- a/src/app/get-started/get-started-tab/get-started-tab.controller.ts
+++ b/src/app/get-started/get-started-tab/get-started-tab.controller.ts
@@ -17,7 +17,7 @@ import { DevfileRegistry, IDevfileMetaData } from '../../../components/api/devfi
 import { CheNotification } from '../../../components/notification/che-notification.factory';
 import { IChePfButtonProperties } from '../../../components/che-pf-widget/button/che-pf-button';
 import { IGetStartedToolbarBindingProperties } from './toolbar/get-started-toolbar.component';
-import { StorageType } from '../../../components/service/storage-type/storage-type.service';
+import { StorageType, StorageTypeService } from '../../../components/service/storage-type/storage-type.service';
 
 
 /**
@@ -34,7 +34,8 @@ export class GetStartedTabController {
     'cheNotification',
     'cheWorkspace',
     'createWorkspaceSvc',
-    'devfileRegistry'
+    'devfileRegistry',
+    'storageTypeService',
   ];
 
   toolbarProps: IGetStartedToolbarBindingProperties;
@@ -46,11 +47,11 @@ export class GetStartedTabController {
   private cheNotification: CheNotification;
   private createWorkspaceSvc: CreateWorkspaceSvc;
   private devfileRegistry: DevfileRegistry;
+  private storageTypeService: StorageTypeService;
 
   private isLoading: boolean = false;
   private isCreating: boolean = false;
   private devfileRegistryUrl: string;
-  private ephemeralMode: boolean;
   private storageType: StorageType;
 
   /**
@@ -61,16 +62,19 @@ export class GetStartedTabController {
     cheNotification: CheNotification,
     cheWorkspace: CheWorkspace,
     createWorkspaceSvc: CreateWorkspaceSvc,
-    devfileRegistry: DevfileRegistry
+    devfileRegistry: DevfileRegistry,
+    storageTypeService: StorageTypeService,
   ) {
     this.$log = $log;
     this.cheNotification = cheNotification;
     this.createWorkspaceSvc = createWorkspaceSvc;
     this.devfileRegistry = devfileRegistry;
+    this.storageTypeService = storageTypeService;
 
     this.toolbarProps = {
       devfiles: [],
-      ephemeralMode: false,
+      storageType: StorageType.persistent,
+      storageTypeDisabled: true,
       onFilterChange: filtered => this.onFilterChange(filtered),
       onStorageTypeChange: type => this.onStorageTypeChange(type),
     };
@@ -79,13 +83,12 @@ export class GetStartedTabController {
     cheWorkspace.fetchWorkspaceSettings().then(() => {
       const workspaceSettings = cheWorkspace.getWorkspaceSettings();
       this.devfileRegistryUrl = workspaceSettings && workspaceSettings.cheWorkspaceDevfileRegistryUrl;
-      this.ephemeralMode = workspaceSettings['che.workspace.persist_volumes.default'] === 'false';
-      if (this.ephemeralMode) {
-        this.storageType = StorageType.ephemeral;
-      } else {
-        this.storageType = StorageType.persistent;
-      }
-      this.toolbarProps.ephemeralMode = this.ephemeralMode;
+
+      return this.storageTypeService.ready;
+    }).then(() => {
+      this.toolbarProps.storageType = this.storageTypeService.getPreferredType();
+      this.toolbarProps.storageTypeDisabled = this.storageTypeService.getAvailableTypes().length === 1;
+
       return this.init();
     }).finally(() => {
       this.isLoading = false;

--- a/src/app/get-started/get-started-tab/get-started-tab.html
+++ b/src/app/get-started/get-started-tab/get-started-tab.html
@@ -23,8 +23,8 @@
 
     <!-- toolbar -->
     <get-started-toolbar devfiles="getStartedTabController.toolbarProps.devfiles"
-      ephemeral-mode="getStartedTabController.toolbarProps.ephemeralMode"
-      storage-typr="getStartedTabController.toolbarProps.storageType"
+      storage-type="getStartedTabController.toolbarProps.storageType"
+      storage-type-disabled="getStartedTabController.toolbarProps.storageTypeDisabled"
       on-filter-change="getStartedTabController.toolbarProps.onFilterChange($filtered)"
       on-storage-type-change="getStartedTabController.toolbarProps.onStorageTypeChange($storageType)">
     </get-started-toolbar>

--- a/src/app/get-started/get-started-tab/toolbar/get-started-toolbar.component.ts
+++ b/src/app/get-started/get-started-tab/toolbar/get-started-toolbar.component.ts
@@ -17,14 +17,16 @@ import { StorageType } from '../../../../components/service/storage-type/storage
 
 export interface IGetStartedToolbarBindingProperties {
   devfiles: IDevfileMetaData[];
-  ephemeralMode: boolean;
+  storageType: StorageType;
+  storageTypeDisabled: boolean;
   onFilterChange: ($filtered: IDevfileMetaData[]) => void;
   onStorageTypeChange: ($storageType: StorageType) => void;
 }
 
 export interface IGetStartedToolbarComponentInputBindings {
   devfiles: IDevfileMetaData[];
-  ephemeralMode: boolean;
+  storageType: StorageType;
+  storageTypeDisabled: boolean;
 }
 export interface IGetStartedToolbarComponentBindings extends IGetStartedToolbarComponentInputBindings {
   onFilterChange: (eventObj: { $filtered: IDevfileMetaData[] }) => void;
@@ -43,7 +45,8 @@ export class GetStartedToolbarComponent implements ng.IComponentOptions, IGetSta
 
   bindings = {
     devfiles: '<',
-    ephemeralMode: '<',
+    storageType: '<',
+    storageTypeDisabled: '<',
     onFilterChange: '&',
     onStorageTypeChange: '&'
   };

--- a/src/app/get-started/get-started-tab/toolbar/get-started-toolbar.controller.ts
+++ b/src/app/get-started/get-started-tab/toolbar/get-started-toolbar.controller.ts
@@ -30,11 +30,13 @@ export class GetStartedToolbarController implements IGetStartedToolbarComponentB
   ];
 
   // component bindings
-  ephemeralMode: boolean;
+  storageType: StorageType;
+  storageTypeDisabled: boolean;
   devfiles: IDevfileMetaData[];
   onFilterChange: (eventObj: { $filtered: IDevfileMetaData[] }) => void;
   onStorageTypeChange: (eventObj: { $storageType: StorageType }) => void;
 
+  ephemeralMode: boolean;
   filterInput: IChePfTextInputProperties;
   filterResultsCount: number;
   tmpStorage: IChePfSwitchProperties;
@@ -77,6 +79,13 @@ export class GetStartedToolbarController implements IGetStartedToolbarComponentB
   $onChanges(onChangesObj: OnChangeObject): void {
     if (onChangesObj.devfiles && onChangesObj.devfiles.currentValue) {
       this.filterDevfiles();
+    }
+    if (onChangesObj.storageType && onChangesObj.storageType.currentValue) {
+      const storageType = onChangesObj.storageType.currentValue;
+      this.ephemeralMode = StorageType[storageType] !== StorageType.persistent;
+    }
+    if (onChangesObj.storageTypeDisabled) {
+      this.tmpStorage.config.disabled = !!onChangesObj.storageTypeDisabled.currentValue;
     }
   }
 

--- a/src/app/get-started/get-started-tab/toolbar/get-started-toolbar.controller.ts
+++ b/src/app/get-started/get-started-tab/toolbar/get-started-toolbar.controller.ts
@@ -82,7 +82,7 @@ export class GetStartedToolbarController implements IGetStartedToolbarComponentB
     }
     if (onChangesObj.storageType && onChangesObj.storageType.currentValue) {
       const storageType = onChangesObj.storageType.currentValue;
-      this.ephemeralMode = StorageType[storageType] !== StorageType.persistent;
+      this.ephemeralMode = storageType !== StorageType.persistent;
     }
     if (onChangesObj.storageTypeDisabled) {
       this.tmpStorage.config.disabled = !!onChangesObj.storageTypeDisabled.currentValue;

--- a/src/app/get-started/get-started-tab/toolbar/get-started-toolbar.html
+++ b/src/app/get-started/get-started-tab/toolbar/get-started-toolbar.html
@@ -16,7 +16,7 @@
           on-change="getStartedToolbarController.tmpStorage.onChange($value)">
         </che-pf-switch>
         <span class="temporary-storage-label" ng-class="{'disabled-state': !getStartedToolbarController.ephemeralMode}">
-          Temporary Storage
+          Temporary Storage {{getStartedToolbarController.ephemeralMode ? 'On' : 'Off'}}
         </span>
         <span class="temporary-storage-tooltip"
           uib-tooltip-html="'{{getStartedToolbarController.tooltipContent}}'"

--- a/src/components/che-pf-widget/switch/che-pf-switch.directive.ts
+++ b/src/components/che-pf-widget/switch/che-pf-switch.directive.ts
@@ -20,6 +20,7 @@ export interface IChePfSwitchProperties extends IChePfInputProperties {
     name: string;
     messageOn?: string;
     messageOff?: string;
+    disabled?: boolean;
   };
   value?: boolean;
   onChange: ($value: boolean) => void;
@@ -31,6 +32,7 @@ interface IChePfSwitchBindings extends IChePfInputBindings {
     name: string;
     messageOn?: string;
     messageOff?: string;
+    disabled?: boolean;
   };
   onChange: (eventObj: { $value: boolean }) => void;
 }

--- a/src/components/che-pf-widget/switch/che-pf-switch.html
+++ b/src/components/che-pf-widget/switch/che-pf-switch.html
@@ -2,11 +2,12 @@
   <input class="pf-c-switch__input"
     ng-model="value"
     ng-change="onChange({ $value: value })"
+    ng-disabled="config.disabled"
     type="checkbox"
     id="{{config.id}}"
     aria-labelledby="switch-with-label-1-on"
     name="{{config.name}}"
-    checked />
+  />
   <span class="pf-c-switch__toggle"></span>
   <span class="pf-c-switch__label pf-m-on"
     ng-if="config.messageOn"

--- a/src/components/service/storage-type/storage-type.service.ts
+++ b/src/components/service/storage-type/storage-type.service.ts
@@ -56,7 +56,7 @@ export class StorageTypeService {
   }
 
   getPreferredType(): StorageType {
-    return this.settings['che.workspace.storage.preferred_type'] as StorageType;
+    return StorageType[this.settings['che.workspace.storage.preferred_type']];
   }
 
   getTextDescription(type: StorageType): string {

--- a/src/components/service/storage-type/storage-type.service.ts
+++ b/src/components/service/storage-type/storage-type.service.ts
@@ -15,9 +15,9 @@ import { CheWorkspace } from '../../api/workspace/che-workspace.factory';
 import { CheBranding } from '../../branding/che-branding';
 
 export enum StorageType {
-  'async' = 'Asynchronous',
-  'ephemeral' = 'Ephemeral',
-  'persistent' = 'Persistent',
+  async = 'Asynchronous',
+  ephemeral = 'Ephemeral',
+  persistent = 'Persistent',
 }
 
 export class StorageTypeService {


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

PatternFly switch component:
- added attribute to disable the component

Storage Type switch on Get Started tab:
- correctly initialize the toggle with the default storage type
- disable the toggle in case when the only storage type is available
![Screenshot_20200901_131000](https://user-images.githubusercontent.com/5887312/91837254-a0f46280-ec54-11ea-8b8b-46c4cc74ae86.png)

Storage Type select on Custom Workspace tab:
- correctly initialize storage type select with the default storage type value
- disable the select in case when the only storage type is available
![Screenshot_20200901_131506](https://user-images.githubusercontent.com/5887312/91837809-3132a780-ec55-11ea-8b24-ad2a68db4d57.png)

- fixes updating the devfile editor on selecting the storage type

### What issues does this PR fix or reference?

fixes https://github.com/eclipse/che/issues/17725
