### PR TITLE
update pull request action

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -6,32 +6,132 @@
 #
 # SPDX-License-Identifier: EPL-2.0
 #
+
 name: PR
+
 # Trigger the workflow on push
 on:
   pull_request:
-    branches: [ master ]
+    branches: [master]
+
+env:
+  DIR_DASHBOARD: che-dashboard
+  DIR_CHE: che
+  IMAGE_VERSION: che-dashboard-pull-${{ github.event.pull_request.number }}
+  ORGANIZATION: docker.io/maxura
+
 jobs:
-  docker-build:
+
+  che-dashboard-build:
     runs-on: ubuntu-18.04
     strategy:
       fail-fast: false
-    env:
-      IMAGE_FULL: quay.io/eclipse/che-dashboard:next
-      CACHE_IMAGE_FULL: docker.io/cheincubator/che-dashboard:cache
     steps:
-    - uses: actions/checkout@v2
-      name: Checkout che-dashboard source code
-    - name: Docker Buildx
-      uses: crazy-max/ghaction-docker-buildx@v1.6.2
-      with:
-        buildx-version: v0.4.1
-    - name: "Docker prepare"
-      run: docker image prune -a -f
-    - name: "Docker build with cache"
-      uses: nick-invision/retry@v1
-      with:
-        timeout_minutes: 100
-        max_attempts: 5
-        retry_wait_seconds: 60
-        command: docker buildx build --platform linux/amd64,linux/s390x --cache-from="type=registry,ref=${CACHE_IMAGE_FULL}" -t ${IMAGE_FULL}  -f apache.Dockerfile .
+      -
+        name: 'Docker Buildx'
+        uses: crazy-max/ghaction-docker-buildx@v3
+      -
+        name: 'Checkout Source Code'
+        uses: actions/checkout@v2
+        with:
+          path: ${{ env.DIR_DASHBOARD }}
+          ref: ${{ github.event.pull_request.head.sha }}
+      -
+        name: 'Cache Docker layers'
+        uses: actions/cache@v2
+        id: cache
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+      -
+        name: 'Docker Prepare'
+        run: docker image prune -a -f
+      -
+        name: 'Prepare Image Name'
+        run: |
+          echo "::set-env name=IMAGE_DASHBOARD::${ORGANIZATION}/che-dashboard:${IMAGE_VERSION}"
+      -
+        name: 'Docker docker.io Login'
+        run: |
+          docker login -u "${{ secrets.DOCKERHUB_MAXURA_USERNAME }}" -p "${{ secrets.DOCKERHUB_MAXURA_PASSWORD }}" docker.io
+      -
+        name: 'Docker Buildx (build)'
+        id: che-dashboard-docker-build
+        uses: nick-invision/retry@v1
+        with:
+          timeout_minutes: 100
+          max_attempts: 5
+          retry_wait_seconds: 60
+          command: |
+            cd ${GITHUB_WORKSPACE}/${DIR_DASHBOARD} && docker buildx build --cache-from "type=local,src=/tmp/.buildx-cache" --cache-to "type=local,dest=/tmp/.buildx-cache" --platform linux/amd64,linux/s390x --push --tag ${IMAGE_DASHBOARD} --file apache.Dockerfile .
+      -
+        name: 'Docker Logout'
+        run: |
+          docker logout
+
+  che-server-build:
+    needs: che-dashboard-build
+    runs-on: ubuntu-18.04
+    strategy:
+      fail-fast: false
+    steps:
+      -
+        name: 'Checkout Source Code'
+        uses: actions/checkout@v2
+        with:
+          repository: 'eclipse/che'
+          ref: master
+          path: ${{ env.DIR_CHE }}
+      -
+        name: 'Set up JDK 11'
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      -
+        name: 'Cache Local Maven Repository'
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      -
+        name: 'Maven Build'
+        run: |
+          cd ${GITHUB_WORKSPACE}/${DIR_CHE} && mvn clean install -DskipTests
+      -
+        name: 'Prepare Image Name'
+        run: |
+          echo "::set-env name=IMAGE_CHE_SERVER::${ORGANIZATION}/che-server:${IMAGE_VERSION}"
+      -
+        name: 'Docker Build'
+        uses: nick-invision/retry@v1
+        env:
+          CHE_VERSION: next
+        with:
+          timeout_minutes: 100
+          max_attempts: 5
+          retry_wait_seconds: 60
+          command: |
+            bash ${GITHUB_WORKSPACE}/${DIR_CHE}/dockerfiles/che/build.sh --skip-tests --tag:${IMAGE_VERSION} --organization:${ORGANIZATION} --build-arg:"CHE_DASHBOARD_VERSION=${IMAGE_VERSION},CHE_DASHBOARD_ORGANIZATION=${ORGANIZATION},CHE_WORKSPACE_LOADER_VERSION=${CHE_VERSION}"
+      -
+        name: 'Docker docker.io Login'
+        run: |
+          docker login -u "${{ secrets.DOCKERHUB_MAXURA_USERNAME }}" -p "${{ secrets.DOCKERHUB_MAXURA_PASSWORD }}" docker.io
+      -
+        name: 'Docker Push'
+        run: |
+          docker push ${IMAGE_CHE_SERVER}
+      -
+        name: 'Docker Logout'
+        run: docker logout
+      -
+        name: 'Comment with image name'
+        uses: actions/github-script@v3
+        with:
+          script: |
+            const { issue: { number: issue_number }, repo: { owner, repo }  } = context;
+            const imageCheServer = '${{ env.IMAGE_CHE_SERVER }}';
+            github.issues.createComment({ issue_number, owner, repo, body: 'Docker image build succeeded: **' + imageCheServer + '**' });


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

This PR updates the GitHub workflow action triggered on pull request. This action now builds two docker images for `che-dashboard` and `che-server` and pushes them to `docker.io/maxura` organization. After the successful build the GH bot leaves a comment with `che-server` image name that can be used for testing.

#### Image name format

`docker.io/maxura/{PRODUCT}>:che-dashboard-pull-{PULL_NUMBER}`

e.g. for this particular pull request two images are built:

`docker.io/maxura/che-dashboard>:che-dashboard-pull-85`
`docker.io/maxura/che-server>:che-dashboard-pull-85`
