### PR TITLE
Block scalar literal style in the devfile editor

### DIFF
--- a/src/components/widget/devfile-editor/devfile-editor.controller.ts
+++ b/src/components/widget/devfile-editor/devfile-editor.controller.ts
@@ -119,7 +119,9 @@ export class DevfileEditorController implements ng.IController, IDevfileEditorCo
       return;
     }
     if (onChangesObj.devfile.currentValue) {
-      this.devfileYaml = jsyaml.safeDump(onChangesObj.devfile.currentValue);
+      this.devfileYaml = jsyaml.safeDump(onChangesObj.devfile.currentValue, {
+        lineWidth: 9999,
+      });
     } else {
       this.devfileYaml = '';
     }

--- a/src/components/widget/devfile-editor/devfile-editor.controller.ts
+++ b/src/components/widget/devfile-editor/devfile-editor.controller.ts
@@ -36,8 +36,8 @@ export class DevfileEditorController implements ng.IController, IDevfileEditorCo
   devfile: che.IWorkspaceDevfile;
   onChange: (eventObj: { $devfile: che.IWorkspaceDevfile, '$editorState': che.IValidation }) => void;
 
-  private devfileYaml: string;
-  private devfileDocsUrl: string;
+  devfileYaml: string;
+  devfileDocsUrl: string;
   private timeoutPromise: ng.IPromise<any>;
 
   // injected services
@@ -63,7 +63,9 @@ export class DevfileEditorController implements ng.IController, IDevfileEditorCo
 
   $onInit(): void {
     this.devfileDocsUrl = this.cheBranding.getDocs().devfile;
-    this.devfileYaml = this.devfile ? jsyaml.safeDump(this.devfile) : '';
+    this.devfileYaml = this.devfile ? jsyaml.safeDump(this.devfile, {
+      lineWidth: 9999,
+    }) : '';
     const yamlService = (window as any).yamlService;
 
     this.cheWorkspace.fetchWorkspaceSettings().then(workspaceSettings =>
@@ -123,7 +125,7 @@ export class DevfileEditorController implements ng.IController, IDevfileEditorCo
     }
   }
 
-  private onChanged(editorState: che.IValidation, value: string): void {
+  onChanged(editorState: che.IValidation, value: string): void {
     if (!editorState.isValid) {
       return;
     }


### PR DESCRIPTION
Signed-off-by: Oleksii Kurinnyi <okurinny@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

This PR makes the devfile editor to use literal style for all block scalars while displaying yaml files.

### What issues does this PR fix or reference?

resolves https://github.com/eclipse/che/issues/15999
