### PR TITLE
Update branding readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Eclipse Che is a next generation Eclipse IDE. This repository is licensed under 
 
 ## Requirements
 
-- Python `v2.7.x`(`v3.x.x`currently not supported)
+- Python `v2.7.x` (`v3.x.x` currently not supported)
 - Node.js `v8.x.x` or `v10.x.x`
 - yarn `v1.13.0` or higher
 
@@ -191,13 +191,17 @@ for example `cheAPI.getWorkspace().getWorkspaces()` for getting the array of the
 
 Mocks are also provided for the Che API, allowing to emulate a real backend for unit tests.
 
+## Branding
+
+Default branding data for the User Dashboard is located in [branding.json](/src/components/branding/branding.json). It can be updated without re-building the project in [product.json](/src/assets/branding/product.json). [product.json](/src/assets/branding/product.json) should contain only values that should overwrite default ones.
+
 ## Configurability
 
-Configurations for User Dashboard could be applied in [product.json](/src/assets/branding/product.json) in `"configuration"` section.
+Configuration defaults for the User Dashboard could be applied in [branding.json](/src/components/branding/branding.json) (or updated in [product.json](/src/assets/branding/product.json)) in `"configuration"` section.
 
 Adding the `"configuration.menu.disabled"` field allows Che Admins to list menu entries they want to hide in the left navigation bar, along with the corresponding routes which will be disabled.
 
-Available values are `"administration"`, `"factories"`,  `"getstarted"`, `"organizations"`, `"stacks"`.
+Available values are `"administration"`, `"factories"`, `"getstarted"`, `"organizations"`, `"stacks"`.
 
 For example,
 
@@ -214,7 +218,7 @@ For example,
 }
 ```
 
-**Note**: Menu entries also may be disabled by default in [branding.constant.ts](https://github.com/eclipse/che-dashboard/blob/master/src/components/branding/branding.constant.ts#L112-L122). In order to force enable such entries they need to be listed in `"configuration.menu.enabled"` field.
+**Note**: In order to force enable such entries they need to be listed in `"configuration.menu.enabled"` field.
 
 In the case of disabling the `"factories"`, `load factory` routing won't be disabled because it is used for creating a new workspace from the devfile URL. For example, `https://che.openshift.io/f?url=https://raw.githubusercontent.com/eclipse/che/master/devfile.yaml` .
 

--- a/src/components/branding/branding.constant.ts
+++ b/src/components/branding/branding.constant.ts
@@ -42,13 +42,14 @@ export const jsonBranding = JSON.stringify({
   'docs': {
     'devfile': 'https://www.eclipse.org/che/docs/che-7/making-a-workspace-portable-using-a-devfile/',
     'workspace': 'https://www.eclipse.org/che/docs/che-7/workspaces-overview/',
-    'factory': 'https://www.eclipse.org/che/docs/factories-getting-started.html',
-    'organization': 'https://www.eclipse.org/che/docs/organizations.html',
-    'converting': 'https://www.eclipse.org/che/docs/che-7/converting-a-che-6-workspace-to-a-che-7-devfile/',
+    'factory': 'https://www.eclipse.org/che/docs/che-7',
+    'organization': 'https://www.eclipse.org/che/docs/che-7',
+    'converting': 'https://www.eclipse.org/che/docs/che-7',
     'certificate': 'https://www.eclipse.org/che/docs/che-7/importing-certificates-to-browsers/',
     'general': 'https://www.eclipse.org/che/docs/che-7',
     'storageTypes': 'https://www.eclipse.org/che/docs/che-7/configuring-storage-types/',
-    'webSocketTroubleshooting': 'https://www.eclipse.org/che/docs/che-7/troubleshooting-network-problems/#troubleshooting-websocket-secure-connections_troubleshooting-network-problems'
+    'webSocketTroubleshooting': 'https://www.eclipse.org/che/docs/che-7/troubleshooting-network-problems/#troubleshooting-websocket-secure-connections_troubleshooting-network-problems',
+    'faq': 'https://www.eclipse.org/che/docs/che-7'
   },
   'configuration': {
     'menu': {

--- a/src/components/branding/branding.json
+++ b/src/components/branding/branding.json
@@ -25,13 +25,14 @@
   "docs": {
     "devfile": "https://www.eclipse.org/che/docs/che-7/making-a-workspace-portable-using-a-devfile/",
     "workspace": "https://www.eclipse.org/che/docs/che-7/workspaces-overview/",
-    "factory": "https://www.eclipse.org/che/docs/factories-getting-started.html",
-    "organization": "https://www.eclipse.org/che/docs/organizations.html",
-    "converting": "https://www.eclipse.org/che/docs/che-7/converting-a-che-6-workspace-to-a-che-7-devfile/",
+    "factory": "https://www.eclipse.org/che/docs/che-7",
+    "organization": "https://www.eclipse.org/che/docs/che-7",
+    "converting": "https://www.eclipse.org/che/docs/che-7",
     "certificate": "https://www.eclipse.org/che/docs/che-7/importing-certificates-to-browsers/",
     "general": "https://www.eclipse.org/che/docs/che-7",
     "storageTypes": "https://www.eclipse.org/che/docs/che-7/configuring-storage-types/",
-    "webSocketTroubleshooting": "https://www.eclipse.org/che/docs/che-7/troubleshooting-network-problems/#troubleshooting-websocket-secure-connections_troubleshooting-network-problems"
+    "webSocketTroubleshooting": "https://www.eclipse.org/che/docs/che-7/troubleshooting-network-problems/#troubleshooting-websocket-secure-connections_troubleshooting-network-problems",
+    "faq": "https://www.eclipse.org/che/docs/che-7"
   },
   "configuration": {
     "menu": {


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

- in `README.md` 
  - added `Branding` section that points default branding data location and how it could be updated without rebuilding the UD;
  - updated `Configurability` section in accordance with latest changes;
- updated obsolete doc links that are still used in the UD (factories, organizations, converting, faq) to point to Introduction to Eclipse Che.
