### PR TITLE
Do not fail in Single-User Mode is keycloak is not found

### DIFF
--- a/src/app/index.module.ts
+++ b/src/app/index.module.ts
@@ -40,6 +40,9 @@ import { DetectSupportedBrowserService } from '../components/service/browser-det
 import { StorageTypeService } from '../components/service/storage-type/storage-type.service';
 import { keycloakSetup } from './keycloak-setup';
 
+// development mode
+const DEV = false;
+
 // init module
 const initModule = angular.module('userDashboard', ['ngAnimate', 'ngCookies', 'ngTouch', 'ngSanitize', 'ngResource', 'ngRoute',
   'angular-websocket', 'ui.bootstrap', 'ngMaterial', 'ngMessages', 'angularMoment', 'angular.filter',
@@ -79,7 +82,7 @@ const keycloakAuth = {
 initModule.constant('keycloakAuth', keycloakAuth);
 
 angular.element(() => {
-  const keycloakSetupPromise = keycloakSetup(cheBranding);
+  const keycloakSetupPromise = keycloakSetup(cheBranding, DEV);
   const brandingReadyPromise = cheBranding.ready
     .catch(errorMessage => {
       const message = `
@@ -149,8 +152,6 @@ initModule.config(['$routeProvider', ($routeProvider: che.route.IRouteProvider) 
 
 
 }]);
-
-const DEV = false;
 
 // configs
 initModule.config(['$routeProvider', ($routeProvider: che.route.IRouteProvider) => {

--- a/src/app/keycloak-setup.ts
+++ b/src/app/keycloak-setup.ts
@@ -66,7 +66,12 @@ export async function keycloakSetup(cheBranding: CheBranding): Promise<IKeycloak
       }
     }
   } catch (e) {
-    const errorMessage = `Can't get Keycloak settings: ` + e.statusText;
+    if (e.status == 404) {
+      //keycloak is not configured. Running in Single User mode
+      return;
+    }
+
+    const errorMessage = `Can't get Keycloak settings: ` + e.status  + ' ' + e.statusText;
     console.warn(errorMessage);
     throw new Error(errorMessage);
   }

--- a/src/app/keycloak-setup.ts
+++ b/src/app/keycloak-setup.ts
@@ -44,7 +44,7 @@ function isOfTypeKeycloakSettingsField (settingField: string): settingField is K
 
 type KeycloakSettingsMap = Map<KeycloakSettingsField, string>;
 
-export async function keycloakSetup(cheBranding: CheBranding): Promise<IKeycloakAuth> {
+export async function keycloakSetup(cheBranding: CheBranding, isDevMode?: boolean): Promise<IKeycloakAuth> {
   const keycloakAuth = {
     isPresent: false,
     keycloak: null,
@@ -66,7 +66,7 @@ export async function keycloakSetup(cheBranding: CheBranding): Promise<IKeycloak
       }
     }
   } catch (e) {
-    if (e.status == 404) {
+    if (e.status == 404 || (isDevMode && e.status == 0)) {
       //keycloak is not configured. Running in Single User mode
       return;
     }
@@ -118,7 +118,7 @@ function buildKeycloakConfig(keycloakSettings: KeycloakSettingsMap): any {
     return {
       url: keycloakSettings.get('che.keycloak.auth_server_url'),
       realm: keycloakSettings.get('che.keycloak.realm'),
-      clientId: keycloakSettings.get('che.keycloak.client_id')  
+      clientId: keycloakSettings.get('che.keycloak.client_id')
     };
   }
 


### PR DESCRIPTION
### What does this PR do?
Makes dashboard don't fail if api/keycloak/settings is not found

### What issues does this PR fix or reference?
It fixes https://github.com/eclipse/che/issues/18095
I've tested multiuser and single-user run on minikube with deployed Helm chart

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
