### PR TITLE
Dashboard should allow IDEs going to fullscreen mode

### DIFF
--- a/src/app/ide/ide.service.ts
+++ b/src/app/ide/ide.service.ts
@@ -182,7 +182,7 @@ class IdeSvc {
     }
 
     // iframe element for IDE application:
-    let iframeElement = '<iframe class=\"ide-page-frame\" id=\"ide-application-iframe\" ng-src=\"{{ideIframeLink}}\" ></iframe>';
+    let iframeElement = '<iframe class=\"ide-page-frame\" id=\"ide-application-iframe\" allow=\"fullscreen *\" ng-src=\"{{ideIframeLink}}\" ></iframe>';
     this.cheUIElementsInjectorService.injectAdditionalElement(iframeParent, iframeElement);
 
     let defer = this.$q.defer();


### PR DESCRIPTION
Signed-off-by: Artem Zatsarynnyi <azatsary@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Allows the embedded IDEs to go into a fullscreen mode by specifying a corresponding feature policy for the nested ide iframe.
`fullscreen` feature policy allows the nested context to use the browser's Clipboard API.

### What issues does this PR fix or reference?
fixes https://github.com/eclipse/che/issues/18330

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
