### PR TITLE
Copy login command to clipboard, or manually from notification

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -49,10 +49,6 @@ jobs:
         name: 'Docker Prepare'
         run: docker image prune -a -f
       -
-        name: 'Prepare Image Name'
-        run: |
-          echo "::set-env name=IMAGE_DASHBOARD::${ORGANIZATION}/che-dashboard:${IMAGE_VERSION}"
-      -
         name: 'Docker docker.io Login'
         run: |
           docker login -u "${{ secrets.DOCKERHUB_MAXURA_USERNAME }}" -p "${{ secrets.DOCKERHUB_MAXURA_PASSWORD }}" docker.io
@@ -65,7 +61,7 @@ jobs:
           max_attempts: 5
           retry_wait_seconds: 60
           command: |
-            cd ${GITHUB_WORKSPACE}/${DIR_DASHBOARD} && docker buildx build --cache-from "type=local,src=/tmp/.buildx-cache" --cache-to "type=local,dest=/tmp/.buildx-cache" --platform linux/amd64,linux/s390x --push --tag ${IMAGE_DASHBOARD} --file apache.Dockerfile .
+            cd ${GITHUB_WORKSPACE}/${DIR_DASHBOARD} && docker buildx build --cache-from "type=local,src=/tmp/.buildx-cache" --cache-to "type=local,dest=/tmp/.buildx-cache" --platform linux/amd64,linux/s390x --push --tag ${ORGANIZATION}/che-dashboard:${IMAGE_VERSION} --file apache.Dockerfile .
       -
         name: 'Docker Logout'
         run: |
@@ -102,10 +98,6 @@ jobs:
         run: |
           cd ${GITHUB_WORKSPACE}/${DIR_CHE} && mvn clean install -DskipTests
       -
-        name: 'Prepare Image Name'
-        run: |
-          echo "::set-env name=IMAGE_CHE_SERVER::${ORGANIZATION}/che-server:${IMAGE_VERSION}"
-      -
         name: 'Docker Build'
         uses: nick-invision/retry@v1
         env:
@@ -123,7 +115,7 @@ jobs:
       -
         name: 'Docker Push'
         run: |
-          docker push ${IMAGE_CHE_SERVER}
+          docker push ${ORGANIZATION}/che-server:${IMAGE_VERSION}
       -
         name: 'Docker Logout'
         run: docker logout
@@ -133,5 +125,5 @@ jobs:
         with:
           script: |
             const { issue: { number: issue_number }, repo: { owner, repo }  } = context;
-            const imageCheServer = '${{ env.IMAGE_CHE_SERVER }}';
+            const imageCheServer = '${{ ${ORGANIZATION}/che-server:${IMAGE_VERSION} }}';
             github.issues.createComment({ issue_number, owner, repo, body: 'Docker image build succeeded: **' + imageCheServer + '**' });

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -125,5 +125,5 @@ jobs:
         with:
           script: |
             const { issue: { number: issue_number }, repo: { owner, repo }  } = context;
-            const imageCheServer = '${{ ${ORGANIZATION}/che-server:${IMAGE_VERSION} }}';
+            const imageCheServer = '${{env.ORGANIZATION}}/che-server:${{env.IMAGE_VERSION}}';
             github.issues.createComment({ issue_number, owner, repo, body: 'Docker image build succeeded: **' + imageCheServer + '**' });

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ Mocks are also provided for the Che API, allowing to emulate a real backend for 
 
 Default branding data for the User Dashboard is located in [branding.json](/src/components/branding/branding.json). It can be updated without re-building the project in [product.json](/src/assets/branding/product.json). [product.json](/src/assets/branding/product.json) should contain only values that should overwrite default ones.
 
-## Configurability
+### Configurability
 
 Configuration defaults for the User Dashboard could be applied in [branding.json](/src/components/branding/branding.json) (or updated in [product.json](/src/assets/branding/product.json)) in `"configuration"` section.
 
@@ -253,6 +253,18 @@ For example, this config disables kubernetes namespace selector:
     "features": {
       "disabled": ["kubernetesNamespaceSelector"]
     }
+  }
+}
+```
+
+Field `"configuration.cheCliTool"` should contain the name of a CLI tool that is recommended to be used to work with Che Server from the terminal. Possible values are `"chectl"` (default), `"crwctl"`.
+
+Example:
+
+```json
+{
+  "configuration": {
+    "cheCliTool": "chectl"
   }
 }
 ```

--- a/e2e/widgets/che-notification/che-notification.po.js
+++ b/e2e/widgets/che-notification/che-notification.po.js
@@ -14,8 +14,8 @@
 const EC = protractor.ExpectedConditions;
 const asyncTimeout = 10000;
 
-const CheInfoNotification = function () {
-  this.notificationElements = $$('.che-notification-info');
+const CheSuccessNotification = function () {
+  this.notificationElements = $$('.che-notification-success');
 
   this.getNotificationElements = () => {
     return this.notificationElements;
@@ -66,5 +66,5 @@ const CheErrorNotification = function () {
 
 };
 
-module.exports.info = new CheInfoNotification();
+module.exports.info = new CheSuccessNotification();
 module.exports.error = new CheErrorNotification();

--- a/src/app/admin/user-management/add-user/add-user.controller.ts
+++ b/src/app/admin/user-management/add-user/add-user.controller.ts
@@ -10,6 +10,7 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 'use strict';
+import { CheNotification } from '../../../../components/notification/che-notification.factory';
 import {AdminsUserManagementCtrl} from '../user-management.controller';
 
 /**
@@ -22,7 +23,7 @@ export class AdminsAddUserController {
 
   private $mdDialog: ng.material.IDialogService;
   private lodash: any;
-  private cheNotification: any;
+  private cheNotification: CheNotification;
   private cheUser: any;
   private callbackController: AdminsUserManagementCtrl;
   private newUserName: string;
@@ -101,7 +102,7 @@ export class AdminsAddUserController {
   private finish(): void {
     this.$mdDialog.hide();
     this.callbackController.updateUsers();
-    this.cheNotification.showInfo('User successfully created.');
+    this.cheNotification.showSuccess('User successfully created.');
   }
 
   /**

--- a/src/app/admin/user-management/user-details/user-details.controller.ts
+++ b/src/app/admin/user-management/user-details/user-details.controller.ts
@@ -215,7 +215,7 @@ export class AdminUserDetailsController {
     let promise = this.cheProfile.setAttributes(this.profileAttributes, this.userId);
 
     promise.then(() => {
-      this.cheNotification.showInfo('Profile successfully updated.');
+      this.cheNotification.showSuccess('Profile successfully updated.');
       this.updateData();
     }, (error: any) => {
         this.profileAttributes = angular.copy(this.profile.attributes);

--- a/src/app/admin/user-management/user-management.controller.ts
+++ b/src/app/admin/user-management/user-management.controller.ts
@@ -209,9 +209,9 @@ export class AdminsUserManagementCtrl {
           this.cheNotification.showError('Delete failed.');
         } else {
           if (numberToDelete === 1) {
-            this.cheNotification.showInfo('Selected user has been removed.');
+            this.cheNotification.showSuccess('Selected user has been removed.');
           } else {
-            this.cheNotification.showInfo('Selected users have been removed.');
+            this.cheNotification.showSuccess('Selected users have been removed.');
           }
         }
       });

--- a/src/app/administration/docker-registry/docker-registry-list/docker-registry-list.controller.ts
+++ b/src/app/administration/docker-registry/docker-registry-list/docker-registry-list.controller.ts
@@ -142,9 +142,9 @@ export class DockerRegistryListController {
           this.cheNotification.showError('Delete failed.');
         } else {
           if (numberToDelete === 1) {
-            this.cheNotification.showInfo(currentRegistryAddress + ' has been removed.');
+            this.cheNotification.showSuccess(currentRegistryAddress + ' has been removed.');
           } else {
-            this.cheNotification.showInfo('Selected registries have been removed.');
+            this.cheNotification.showSuccess('Selected registries have been removed.');
           }
         }
       });

--- a/src/app/demo-components/demo-components.controller.ts
+++ b/src/app/demo-components/demo-components.controller.ts
@@ -139,19 +139,19 @@ export class DemoComponentsController {
       },
       applyButton: {
         action: () => {
-          this.cheNotification.showInfo(`Button 'Apply' was clicked.`);
+          this.cheNotification.showSuccess(`Button 'Apply' was clicked.`);
         },
         disabled: false
       },
       saveButton: {
         action: () => {
-          this.cheNotification.showInfo(`Button 'Save' was clicked.`);
+          this.cheNotification.showSuccess(`Button 'Save' was clicked.`);
         },
         disabled: false
       },
       cancelButton: {
         action: () => {
-          this.cheNotification.showInfo(`Button 'Cancel' was clicked.`);
+          this.cheNotification.showSuccess(`Button 'Cancel' was clicked.`);
         },
         disabled: false
       }

--- a/src/app/factories/create-factory/config-file-tab/factory-from-file.controller.ts
+++ b/src/app/factories/create-factory/config-file-tab/factory-from-file.controller.ts
@@ -89,7 +89,7 @@ export class FactoryFromFileCtrl {
       reader.onload = function () {
         try {
           ctrl.factoryContent = $filter('json')(angular.fromJson(reader.result.toString()), 2);
-          ctrl.cheNotification.showInfo('Successfully loaded file\'s configuration ' + uploadedFileName + '.');
+          ctrl.cheNotification.showSuccess('Successfully loaded file\'s configuration ' + uploadedFileName + '.');
         } catch (e) {
           // invalid JSON
           ctrl.factoryContent = null;

--- a/src/app/factories/factory-details/information-tab/factory-information/factory-information.controller.ts
+++ b/src/app/factories/factory-details/information-tab/factory-information/factory-information.controller.ts
@@ -249,7 +249,7 @@ export class FactoryInformationController {
 
     promise.then((factory: che.IFactory) => {
       this.factory = factory;
-      this.cheNotification.showInfo('Factory information successfully updated.');
+      this.cheNotification.showSuccess('Factory information successfully updated.');
     }, (error: any) => {
       this.cheNotification.showError(error.data.message ? error.data.message : 'Update factory failed.');
       this.$log.log(error);
@@ -283,7 +283,7 @@ export class FactoryInformationController {
 
     promise.then((factory: che.IFactory) => {
       this.factory = factory;
-      this.cheNotification.showInfo('Factory information successfully updated.');
+      this.cheNotification.showSuccess('Factory information successfully updated.');
     }, (error: any) => {
       this.factoryContent = this.$filter('json')(this.copyOriginFactory, 2);
       this.cheNotification.showError(error.data.message ? error.data.message : 'Update factory failed.');

--- a/src/app/factories/list-factories/list-factories.controller.ts
+++ b/src/app/factories/list-factories/list-factories.controller.ts
@@ -150,7 +150,7 @@ export class ListFactoriesController {
         if (isError) {
           this.cheNotification.showError('Delete failed.');
         } else {
-          this.cheNotification.showInfo('Selected ' + (numberToDelete === 1 ? 'factory' : 'factories') + ' has been removed.');
+          this.cheNotification.showSuccess('Selected ' + (numberToDelete === 1 ? 'factory' : 'factories') + ' has been removed.');
         }
       });
     });

--- a/src/app/navbar/navbar.controller.ts
+++ b/src/app/navbar/navbar.controller.ts
@@ -10,7 +10,6 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 'use strict';
-import { link } from 'angular-route';
 import { CheAPI } from '../../components/api/che-api.factory';
 import { CheKeycloak } from '../../components/api/che-keycloak.factory';
 import { CheService } from '../../components/api/che-service.factory';
@@ -58,6 +57,7 @@ export class CheNavBarController {
       }
     },
     {
+      // default item name, it's updated in the constructor
       name: 'Copy Login Command',
       onclick: () => {
         this.copyLoginCommand();
@@ -117,6 +117,9 @@ export class CheNavBarController {
     this.cheNotification = cheNotification;
     this.chePermissions = chePermissions;
     this.cheService = cheService;
+
+    // update the default menu item name with a CLI tool name
+    this.accountItems[1].name = `Copy ${cheDashboardConfigurationService.getCliTool()} Login Command`;
 
     const handler = (workspaces: Array<che.IWorkspace>) => {
       this.workspacesNumber = workspaces.length;

--- a/src/app/navbar/navbar.controller.ts
+++ b/src/app/navbar/navbar.controller.ts
@@ -10,12 +10,14 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 'use strict';
-import {CheAPI} from '../../components/api/che-api.factory';
-import {CheKeycloak} from '../../components/api/che-keycloak.factory';
-import {CheService} from '../../components/api/che-service.factory';
+import { link } from 'angular-route';
+import { CheAPI } from '../../components/api/che-api.factory';
+import { CheKeycloak } from '../../components/api/che-keycloak.factory';
+import { CheService } from '../../components/api/che-service.factory';
 import { CheDashboardConfigurationService } from '../../components/branding/che-dashboard-configuration.service';
+import { CheNotification } from '../../components/notification/che-notification.factory';
 
-type ConfigurableMenu = { [key in che.ConfigurableMenuItem ]: string };
+type ConfigurableMenu = { [key in che.ConfigurableMenuItem]: string };
 
 const CONFIGURABLE_MENU: ConfigurableMenu = {
   administration: '#/administration',
@@ -34,11 +36,14 @@ export const MENU_ITEM = angular.extend({
 export class CheNavBarController {
 
   static $inject = [
+    '$document',
     '$location',
     '$scope',
+    '$window',
     'cheAPI',
     'cheDashboardConfigurationService',
     'cheKeycloak',
+    'cheNotification',
     'chePermissions',
     'cheService',
   ];
@@ -53,6 +58,12 @@ export class CheNavBarController {
       }
     },
     {
+      name: 'Copy Login Command',
+      onclick: () => {
+        this.copyLoginCommand();
+      }
+    },
+    {
       name: 'Logout',
       onclick: () => {
         this.logout();
@@ -60,11 +71,14 @@ export class CheNavBarController {
     }
   ];
 
+  private $document: ng.IDocumentService;
   private $location: ng.ILocationService;
   private $scope: ng.IScope;
+  private $window: ng.IWindowService;
   private cheAPI: CheAPI;
   private cheDashboardConfigurationService: CheDashboardConfigurationService;
   private cheKeycloak: CheKeycloak;
+  private cheNotification: CheNotification;
   private chePermissions: che.api.IChePermissions;
   private cheService: CheService;
 
@@ -82,19 +96,25 @@ export class CheNavBarController {
    * Default constructor
    */
   constructor(
+    $document: ng.IDocumentService,
     $location: ng.ILocationService,
     $scope: ng.IScope,
+    $window: ng.IWindowService,
     cheAPI: CheAPI,
     cheDashboardConfigurationService: CheDashboardConfigurationService,
     cheKeycloak: CheKeycloak,
+    cheNotification: CheNotification,
     chePermissions: che.api.IChePermissions,
     cheService: CheService,
   ) {
+    this.$document = $document;
     this.$location = $location;
     this.$scope = $scope;
+    this.$window = $window;
     this.cheAPI = cheAPI;
     this.cheDashboardConfigurationService = cheDashboardConfigurationService;
     this.cheKeycloak = cheKeycloak;
+    this.cheNotification = cheNotification;
     this.chePermissions = chePermissions;
     this.cheService = cheService;
 
@@ -186,7 +206,7 @@ export class CheNavBarController {
    * @return {string}
    */
   getUserName(): string {
-    const {attributes, email} = this.profile;
+    const { attributes, email } = this.profile;
     const fullName = this.cheAPI.getProfile().getFullName(attributes).trim();
 
     return fullName ? fullName : email;
@@ -244,6 +264,64 @@ export class CheNavBarController {
    */
   private gotoProfile(): void {
     this.$location.path('/account').search({});
+  }
+
+  /**
+   * Copies login command in clipboard.
+   */
+  private copyLoginCommand(): void {
+    const loginCommand = this.getLoginCommand();
+    try {
+      const copyToClipboardEl = this.$window.document.createElement('span');
+      const bodyEl = this.$document.find('body');
+      copyToClipboardEl.appendChild(document.createTextNode(loginCommand));
+      copyToClipboardEl.id = 'copy-to-clipboard';
+      angular.element(bodyEl.append(copyToClipboardEl));
+
+      const range = this.$window.document.createRange();
+      range.selectNode(copyToClipboardEl);
+      this.$window.getSelection().removeAllRanges();
+      this.$window.getSelection().addRange(range);
+
+      this.$window.document.execCommand('copy');
+      this.$window.getSelection().removeAllRanges();
+      copyToClipboardEl.remove();
+
+      this.cheNotification.showSuccess('The login command copied to clipboard.');
+    } catch (e) {
+      console.error('Failed to put login to clipboard. Error: ', e);
+
+      this.cheNotification.showWarning('Failed to put login command to clipboard.');
+
+      const messageId = 'refresh-token-message';
+      const linkButtonId = 'refresh-token-show-button';
+      const tokenBoxId = 'refresh-token-box';
+      const hiddenCssClass = 'refresh-token--hidden';
+      this.cheNotification.showInfo(`
+        <script>
+          $('#${linkButtonId}').on('click', (e) => {
+            e.preventDefault();
+            // show token box
+            const tokenBoxEl = document.querySelector('#${tokenBoxId}');
+            tokenBoxEl.classList.remove('${hiddenCssClass}');
+            // hide info message
+            const messageEl = document.querySelector('#${messageId}');
+            messageEl.classList.add('${hiddenCssClass}');
+            return false;
+          });
+        </script>
+        <div>
+          <div id="${messageId}"><a id="${linkButtonId}">Click here</a> to see the login command and copy it manually.</div>
+          <pre id="${tokenBoxId}" class="${hiddenCssClass}">${loginCommand}</pre>
+        </div>
+        `, { title: 'Login command', delay: 20000 });
+    }
+  }
+
+  private getLoginCommand(): string {
+    const host = this.$window.location.host;
+    const token = this.cheKeycloak.refreshToken;
+    return `chectl auth:login ${host} -t ${token}`;
   }
 
   /**

--- a/src/app/navbar/navbar.styl
+++ b/src/app/navbar/navbar.styl
@@ -308,3 +308,15 @@ che-nav-bar
 
 .navbar-primary
   color $primary-color !important
+
+#refresh-token-box
+  display inherit
+  height 210px
+  margin-top 7px
+  white-space normal
+
+#refresh-token-show-button
+  font-weight bold
+
+.refresh-token--hidden
+  display none !important

--- a/src/app/organizations/organization-details/organization-workspaces/list-organization-workspaces.controller.ts
+++ b/src/app/organizations/organization-details/organization-workspaces/list-organization-workspaces.controller.ts
@@ -45,7 +45,7 @@ export class ListOrganizationWorkspacesController {
   /**
    * Service for displaying notifications.
    */
-  private cheNotification: any;
+  private cheNotification: CheNotification;
   /**
    * Service for displaying dialogs.
    */
@@ -250,9 +250,9 @@ export class ListOrganizationWorkspacesController {
           this.cheNotification.showError('Delete failed.');
         } else {
           if (numberToDelete === 1) {
-            this.cheNotification.showInfo(workspaceName + ' has been removed.');
+            this.cheNotification.showSuccess(workspaceName + ' has been removed.');
           } else {
-            this.cheNotification.showInfo('Selected workspaces have been removed.');
+            this.cheNotification.showSuccess('Selected workspaces have been removed.');
           }
         }
       });

--- a/src/app/teams/team-details/team-members/list-team-members.controller.ts
+++ b/src/app/teams/team-details/team-members/list-team-members.controller.ts
@@ -374,7 +374,7 @@ export class ListTeamMembersController {
     }).finally(() => {
       this.isLoading = false;
       if (unregistered.length > 0) {
-        this.cheNotification.showInfo('User' + (unregistered.length > 1 ? 's ' : ' ') + unregistered.join(', ')
+        this.cheNotification.showSuccess('User' + (unregistered.length > 1 ? 's ' : ' ') + unregistered.join(', ')
           + (unregistered.length > 1 ? ' are' : ' is') + ' not registered in the system. The email invitations were sent.');
       }
     });

--- a/src/app/teams/team-details/team-workspaces/list-team-workspaces.controller.ts
+++ b/src/app/teams/team-details/team-workspaces/list-team-workspaces.controller.ts
@@ -10,6 +10,7 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 'use strict';
+import { CheNotification } from '../../../../components/notification/che-notification.factory';
 import {TeamDetailsService} from '../team-details.service';
 /**
  * @ngdoc controller
@@ -41,7 +42,7 @@ export class ListTeamWorkspacesController {
   /**
    * Service for displaying notifications.
    */
-  private cheNotification: any;
+  private cheNotification: CheNotification;
   /**
    * Service for displaying dialogs.
    */
@@ -242,9 +243,9 @@ export class ListTeamWorkspacesController {
           this.cheNotification.showError('Delete failed.');
         } else {
           if (numberToDelete === 1) {
-            this.cheNotification.showInfo(workspaceName + ' has been removed.');
+            this.cheNotification.showSuccess(workspaceName + ' has been removed.');
           } else {
-            this.cheNotification.showInfo('Selected workspaces have been removed.');
+            this.cheNotification.showSuccess('Selected workspaces have been removed.');
           }
         }
       });

--- a/src/app/workspaces/list-workspaces/list-workspaces.controller.ts
+++ b/src/app/workspaces/list-workspaces/list-workspaces.controller.ts
@@ -230,9 +230,9 @@ export class ListWorkspacesCtrl {
           this.cheNotification.showError('Delete failed.');
         } else {
           if (numberToDelete === 1) {
-            this.cheNotification.showInfo(workspaceName + ' has been removed.');
+            this.cheNotification.showSuccess(workspaceName + ' has been removed.');
           } else {
-            this.cheNotification.showInfo('Selected workspaces have been removed.');
+            this.cheNotification.showSuccess('Selected workspaces have been removed.');
           }
         }
       });

--- a/src/app/workspaces/share-workspace/share-workspace.controller.ts
+++ b/src/app/workspaces/share-workspace/share-workspace.controller.ts
@@ -322,9 +322,9 @@ export class ShareWorkspaceController {
           this.cheNotification.showError('Delete failed.');
         } else {
           if (numberToDelete === 1) {
-            this.cheNotification.showInfo(currentUserEmail + 'has been removed.');
+            this.cheNotification.showSuccess(currentUserEmail + 'has been removed.');
           } else {
-            this.cheNotification.showInfo('Selected numbers have been removed.');
+            this.cheNotification.showSuccess('Selected numbers have been removed.');
           }
         }
       });

--- a/src/app/workspaces/workspace-details/export-workspace/dialog/export-workspace-dialog.controller.ts
+++ b/src/app/workspaces/workspace-details/export-workspace/dialog/export-workspace-dialog.controller.ts
@@ -194,7 +194,7 @@ export class ExportWorkspaceDialogController {
    */
   finishWorkspaceExporting(remoteWorkspace: che.IWorkspace) {
     this.exportInCloudSteps += 'Export of workspace ' + this.workspaceDataManager.getName(remoteWorkspace) + 'finished <br>';
-    this.cheNotification.showInfo('Successfully exported the workspace to ' + this.workspaceDataManager.getName(remoteWorkspace) + ' on ' + this.privateCloudUrl);
+    this.cheNotification.showSuccess('Successfully exported the workspace to ' + this.workspaceDataManager.getName(remoteWorkspace) + ' on ' + this.privateCloudUrl);
     this.hide();
   }
 

--- a/src/app/workspaces/workspace-details/workspace-details.controller.ts
+++ b/src/app/workspaces/workspace-details/workspace-details.controller.ts
@@ -482,7 +482,7 @@ export class WorkspaceDetailsController {
     this.workspaceDetailsService.applyChanges(this.workspaceDetails)
       .then(() => {
         this.workspaceDetailsService.removeModified(this.workspaceId);
-        this.cheNotification.showInfo('Workspace updated.');
+        this.cheNotification.showSuccess('Workspace updated.');
         this.$scope.$broadcast('edit-workspace-details', { status: 'saved' });
       })
       .catch((error: any) => {
@@ -520,7 +520,7 @@ export class WorkspaceDetailsController {
 
         let message = 'Workspace updated.';
         message += notifyRestart ? '<br/>To apply changes in running workspace - need to restart it.' : '';
-        this.cheNotification.showInfo(message);
+        this.cheNotification.showSuccess(message);
 
         this.$scope.$broadcast('edit-workspace-details', { status: 'saved' });
       })

--- a/src/app/workspaces/workspace-details/workspace-details.directive.spec.ts
+++ b/src/app/workspaces/workspace-details/workspace-details.directive.spec.ts
@@ -126,8 +126,8 @@ describe(`WorkspaceDetailsController >`, () => {
         };
       })
       .service('cheNotification', function () {
-        this.showInfo = (message: string): void => {
-          console.log('cheNotification.info: ', message);
+        this.showSuccess = (message: string): void => {
+          console.log('cheNotification.success: ', message);
         };
       })
       .service('ideSvc', function () {

--- a/src/components/api/che-keycloak.factory.ts
+++ b/src/components/api/che-keycloak.factory.ts
@@ -71,6 +71,10 @@ export class CheKeycloak {
     return deferred.promise;
   }
 
+  get refreshToken(): string {
+    return this.keycloak.refreshToken;
+  }
+
   isPresent(): boolean {
     return this.keycloak !== null;
   }

--- a/src/components/branding/branding.constant.ts
+++ b/src/components/branding/branding.constant.ts
@@ -61,7 +61,8 @@ export const jsonBranding = JSON.stringify({
     },
     'prefetch': {
       'resources': []
-    }
+    },
+    'cheCliTool': 'chectl'
   },
   'footer': {
     'content': '',

--- a/src/components/branding/branding.json
+++ b/src/components/branding/branding.json
@@ -44,7 +44,8 @@
     },
     "prefetch": {
       "resources": []
-    }
+    },
+    "cheCliTool": "chectl"
   },
   "footer": {
     "content": "",

--- a/src/components/branding/branding.ts
+++ b/src/components/branding/branding.ts
@@ -58,6 +58,8 @@ export type IBrandingFooter = {
   email: { title: string, address: string, subject: string } | null
 }
 
+export type CheCliTool = 'chectl' | 'crwctl';
+
 export type IBrandingConfiguration = {
   menu: {
     disabled: che.ConfigurableMenuItem[];
@@ -69,7 +71,8 @@ export type IBrandingConfiguration = {
   },
   features: {
     disabled: TogglableFeature[];
-  }
+  },
+  cheCliTool: CheCliTool;
 }
 
 export enum TogglableFeature {

--- a/src/components/branding/che-dashboard-configuration.service.ts
+++ b/src/components/branding/che-dashboard-configuration.service.ts
@@ -11,7 +11,7 @@
  */
 'use strict';
 
-import { TogglableFeature } from './branding';
+import { CheCliTool, TogglableFeature } from './branding';
 import { CheBranding } from './che-branding';
 
 export type FooterLink = {
@@ -96,6 +96,10 @@ export class CheDashboardConfigurationService {
       };
     }
     return links;
+  }
+
+  getCliTool(): CheCliTool {
+    return this.cheBranding.getConfiguration().cheCliTool || 'chectl';
   }
 
   private getDisabledItems(): che.ConfigurableMenuItem[] {

--- a/src/components/notification/che-notification.factory.ts
+++ b/src/components/notification/che-notification.factory.ts
@@ -14,7 +14,7 @@ import {CheUIElementsInjectorService} from '../service/injector/che-ui-elements-
 
 const NOTIFICATION_CONTAINER_ELEMENT_ID = 'che-notification-container';
 const ERROR_NOTIFICATION_DISPLAY_TIME = 10000;
-const INFO_NOTIFICATION_DISPLAY_TIME = 5000;
+const SUCCESS_NOTIFICATION_DISPLAY_TIME = 5000;
 const MAX_NOTIFICATION_COUNT = 10;
 
 /**
@@ -139,18 +139,18 @@ export class CheNotification {
     this._removeNotificationContainer();
   }
 
-  showInfo(text: string): void {
+  showSuccess(text: string): void {
     const notificationId = this._getNextNotificationId();
-    const jqInfoNotificationElement = angular.element('<che-info-notification/>');
+    const jqSuccessNotificationElement = angular.element('<che-success-notification/>');
 
-    jqInfoNotificationElement.attr('che-info-text', text);
-    jqInfoNotificationElement.attr('id', notificationId);
+    jqSuccessNotificationElement.attr('che-success-text', text);
+    jqSuccessNotificationElement.attr('id', notificationId);
 
-    this._addNotification(jqInfoNotificationElement);
+    this._addNotification(jqSuccessNotificationElement);
 
     const timeoutPromise = this.$timeout(() => {
-      this._removeNotification(jqInfoNotificationElement);
-    }, INFO_NOTIFICATION_DISPLAY_TIME);
+      this._removeNotification(jqSuccessNotificationElement);
+    }, SUCCESS_NOTIFICATION_DISPLAY_TIME);
     this.timeoutPromiseMap.set(notificationId, timeoutPromise);
   }
 
@@ -186,7 +186,7 @@ export class CheNotification {
 
     const timeoutPromise = this.$timeout(() => {
       this._removeNotification(jqInfoNotificationElement);
-    }, INFO_NOTIFICATION_DISPLAY_TIME);
+    }, SUCCESS_NOTIFICATION_DISPLAY_TIME);
     this.timeoutPromiseMap.set(notificationId, timeoutPromise);
   }
 }

--- a/src/components/notification/che-notification.factory.ts
+++ b/src/components/notification/che-notification.factory.ts
@@ -15,6 +15,7 @@ import {CheUIElementsInjectorService} from '../service/injector/che-ui-elements-
 const NOTIFICATION_CONTAINER_ELEMENT_ID = 'che-notification-container';
 const ERROR_NOTIFICATION_DISPLAY_TIME = 10000;
 const SUCCESS_NOTIFICATION_DISPLAY_TIME = 5000;
+const INFO_NOTIFICATION_DISPLAY_TIME = 5000;
 const MAX_NOTIFICATION_COUNT = 10;
 
 /**
@@ -137,6 +138,24 @@ export class CheNotification {
       hideNotificationElement.remove();
     }
     this._removeNotificationContainer();
+  }
+
+  showInfo(text: string, options?: { delay?: number, title?: string}): void {
+    const delay = options && options.delay ? options.delay : INFO_NOTIFICATION_DISPLAY_TIME;
+
+    const notificationId = this._getNextNotificationId();
+    const jqInfoNotificationElement = angular.element('<che-info-notification/>');
+
+    jqInfoNotificationElement.attr('che-info-title', options && options.title);
+    jqInfoNotificationElement.attr('che-info-text', text);
+    jqInfoNotificationElement.attr('id', notificationId);
+
+    this._addNotification(jqInfoNotificationElement);
+
+    const timeoutPromise = this.$timeout(() => {
+      this._removeNotification(jqInfoNotificationElement);
+    }, delay);
+    this.timeoutPromiseMap.set(notificationId, timeoutPromise);
   }
 
   showSuccess(text: string): void {

--- a/src/components/widget/notification/che-info-notification.directive.ts
+++ b/src/components/widget/notification/che-info-notification.directive.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2015-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+'use strict';
+
+interface ICheInfoNotificationAttributes extends ng.IAttributes {
+  cheInfoTitle: string;
+  cheInfoText: string;
+}
+
+interface ICheInfoNotificationScope extends ng.IScope {
+  hideNotification: () => void;
+}
+
+/**
+ * Defines a directive for info notification.
+ * @author Oleksii Kurinnyi
+ */
+export class CheInfoNotification implements ng.IDirective {
+
+  restrict = 'E';
+  replace = true;
+
+  scope = {};
+
+  /**
+   * Template for the info notification.
+   * @param $element
+   * @param $attrs
+   * @returns {string} the template
+   */
+  template($element: ng.IAugmentedJQuery, $attrs: ICheInfoNotificationAttributes): string {
+    let infoTitle = $attrs.cheInfoTitle || 'Info';
+    let infoText = $attrs.cheInfoText || '';
+    return `
+<md-toast class="che-notification-info" layout="row" flex layout-align="start start">
+  <i class="che-notification-info-icon fa fa-info fa-2x"></i>
+  <div flex="90" layout="column" layout-align="start start">
+    <span flex class="che-notification-info-title">
+      <b>${infoTitle}</b>
+    </span>
+    <span flex class="che-notification-message">${infoText}</span>
+  </div>
+  <i class="che-notification-close-icon fa fa-times" ng-click="hideNotification()"/>
+</md-toast>`;
+  }
+
+  link($scope: ICheInfoNotificationScope, $element: ng.IAugmentedJQuery) {
+    $scope.hideNotification = () => {
+      $element.addClass('hide-notification');
+    };
+  }
+}

--- a/src/components/widget/notification/che-notification.styl
+++ b/src/components/widget/notification/che-notification.styl
@@ -5,7 +5,7 @@ div#che-notification-container
   top 55px
   right 0
 
-md-toast.che-notification-info,
+md-toast.che-notification-success,
 md-toast.che-notification-error,
 md-toast.che-notification-warning
   transition-delay 0s
@@ -28,7 +28,7 @@ md-toast.hide-notification
   padding 0
   margin 0
 
-md-toast.che-notification-info div,
+md-toast.che-notification-success div,
 md-toast.che-notification-error div,
 md-toast.che-notification-warning div
   justify-content flex-start
@@ -37,7 +37,7 @@ i.che-notification-close-icon
   margin 2px 5px
   color $clear-foggy-sky-color
 
-i.che-notification-info-icon
+i.che-notification-success-icon
   margin 5px 10px
   color $che-green-color
 
@@ -47,12 +47,12 @@ i.che-notification-error-icon
 
 i.che-notification-warning-icon
   margin 5px 10px
-  color $warning-color 
+  color $warning-color
 
-md-toast.che-notification-info
+md-toast.che-notification-success
   color #3c763d
 
-md-toast.che-notification-info span,
+md-toast.che-notification-success span,
 md-toast.che-notification-error span,
 md-toast.che-notification-warning span
   margin-left 5px

--- a/src/components/widget/notification/che-notification.styl
+++ b/src/components/widget/notification/che-notification.styl
@@ -8,6 +8,7 @@ div#che-notification-container
 md-toast.che-notification-success,
 md-toast.che-notification-error,
 md-toast.che-notification-warning
+md-toast.che-notification-info
   transition-delay 0s
   transition .3s
   box-shadow 0 1px 1px 2px rgba(0, 0, 0, 0.15)
@@ -31,6 +32,7 @@ md-toast.hide-notification
 md-toast.che-notification-success div,
 md-toast.che-notification-error div,
 md-toast.che-notification-warning div
+md-toast.che-notification-info div
   justify-content flex-start
 
 i.che-notification-close-icon
@@ -49,12 +51,19 @@ i.che-notification-warning-icon
   margin 5px 10px
   color $warning-color
 
+i.che-notification-info-icon
+  margin 5px 10px
+  padding-left 8px
+  padding-right 8px
+  color $primary-color
+
 md-toast.che-notification-success
   color #3c763d
 
 md-toast.che-notification-success span,
 md-toast.che-notification-error span,
 md-toast.che-notification-warning span
+md-toast.che-notification-info span
   margin-left 5px
   max-height 100%
   overflow auto
@@ -67,3 +76,6 @@ span.che-notification-message
 
 span.che-notification-warning-title
   color $warning-color
+
+span.che-notification-info-title
+  color $primary-color

--- a/src/components/widget/notification/che-success-notification.directive.ts
+++ b/src/components/widget/notification/che-success-notification.directive.ts
@@ -11,19 +11,19 @@
  */
 'use strict';
 
-interface ICheInfoNotificationAttributes extends ng.IAttributes {
-  cheInfoText: string;
+interface ICheSuccessNotificationAttributes extends ng.IAttributes {
+  cheSuccessText: string;
 }
 
-interface ICheInfoNotificationScope extends ng.IScope {
+interface ICheSuccessNotificationScope extends ng.IScope {
   hideNotification: () => void;
 }
 
 /**
- * Defines a directive for info notification.
+ * Defines a directive for success notification.
  * @author Oleksii Orel
  */
-export class CheInfoNotification implements ng.IDirective {
+export class CheSuccessNotification implements ng.IDirective {
 
   restrict = 'E';
   replace = true;
@@ -31,24 +31,24 @@ export class CheInfoNotification implements ng.IDirective {
   scope = {};
 
   /**
-   * Template for the info notification.
+   * Template for the success notification.
    * @param $element
    * @param $attrs
    * @returns {string} the template
    */
-  template($element: ng.IAugmentedJQuery, $attrs: ICheInfoNotificationAttributes): string {
-    let infoText = $attrs.cheInfoText || '';
+  template($element: ng.IAugmentedJQuery, $attrs: ICheSuccessNotificationAttributes): string {
+    let successText = $attrs.cheSuccessText || '';
     return '<md-toast class="che-notification-info" layout="row" flex layout-align="start start">' +
-      '<i class="che-notification-info-icon fa fa-check fa-2x"></i>' +
+      '<i class="che-notification-success-icon fa fa-check fa-2x"></i>' +
       '<div flex="90" layout="column" layout-align="start start">' +
-      '<span flex class="che-notification-info-title"><b>Success</b></span>' +
-      '<span flex class="che-notification-message">' + infoText + '</span>' +
+      '<span flex class="che-notification-success-title"><b>Success</b></span>' +
+      '<span flex class="che-notification-message">' + successText + '</span>' +
       '</div>' +
       '<i class="che-notification-close-icon fa fa-times" ng-click="hideNotification()"/>' +
       '</md-toast>';
   }
 
-  link($scope: ICheInfoNotificationScope, $element: ng.IAugmentedJQuery) {
+  link($scope: ICheSuccessNotificationScope, $element: ng.IAugmentedJQuery) {
     $scope.hideNotification = () => {
       $element.addClass('hide-notification');
     };

--- a/src/components/widget/widget-config.ts
+++ b/src/components/widget/widget-config.ts
@@ -76,6 +76,7 @@ import {CheToolbar} from './toolbar/che-toolbar.directive';
 import {CheErrorNotification} from './notification/che-error-notification.directive';
 import {CheSuccessNotification} from './notification/che-success-notification.directive';
 import {CheWarningNotification} from './notification/che-warning-notification.directive';
+import {CheInfoNotification} from './notification/che-info-notification.directive';
 import {ChePopup} from './popup/che-popup.directive';
 import {CheModalPopup} from './popup/che-modal-popup.directive';
 import {CheShowArea} from './show-area/che-show-area.directive';
@@ -192,6 +193,7 @@ export class WidgetConfig {
     register.directive('cheErrorNotification', CheErrorNotification);
     register.directive('cheSuccessNotification', CheSuccessNotification);
     register.directive('cheWarningNotification', CheWarningNotification);
+    register.directive('cheInfoNotification', CheInfoNotification);
     // wrapper for popup
     register.directive('chePopup', ChePopup);
     register.directive('cheModalPopup', CheModalPopup);

--- a/src/components/widget/widget-config.ts
+++ b/src/components/widget/widget-config.ts
@@ -74,7 +74,7 @@ import {CheToggleButton} from './toggle-button/che-toggle-button.directive';
 import {CheToggle} from './toggle-button/che-toggle.directive';
 import {CheToolbar} from './toolbar/che-toolbar.directive';
 import {CheErrorNotification} from './notification/che-error-notification.directive';
-import {CheInfoNotification} from './notification/che-info-notification.directive';
+import {CheSuccessNotification} from './notification/che-success-notification.directive';
 import {CheWarningNotification} from './notification/che-warning-notification.directive';
 import {ChePopup} from './popup/che-popup.directive';
 import {CheModalPopup} from './popup/che-modal-popup.directive';
@@ -190,7 +190,7 @@ export class WidgetConfig {
     register.directive('cheToolbar', CheToolbar);
     // notifications
     register.directive('cheErrorNotification', CheErrorNotification);
-    register.directive('cheInfoNotification', CheInfoNotification);
+    register.directive('cheSuccessNotification', CheSuccessNotification);
     register.directive('cheWarningNotification', CheWarningNotification);
     // wrapper for popup
     register.directive('chePopup', ChePopup);


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

This PR adds ability to user to get login command copied to clipboard, or if that's not possible a notification will appear where user can copy the command manually.


<details>
  <summary>Screenshots</summary>

  ##### Menu item

  <img width="311" alt="Screenshot 2020-11-16 at 14 19 14" src="https://user-images.githubusercontent.com/16220722/99251901-c6861680-2816-11eb-86cf-68efd587a05c.png">

  <hr/>

  ##### Login command has been put to clipboard successfully

<img width="724" alt="Screenshot 2020-11-16 at 15 20 33" src="https://user-images.githubusercontent.com/16220722/99257498-ca6a6680-281f-11eb-8dc9-0a123f986182.png">

  <hr/>

  ##### Failed to put login command to clipboard

<img width="724" alt="Screenshot 2020-11-16 at 15 22 22" src="https://user-images.githubusercontent.com/16220722/99257514-d2c2a180-281f-11eb-8f02-eefdce632558.png">

<hr/>

  ##### Copy login command manually

<img width="724" alt="Screenshot 2020-11-16 at 15 22 29" src="https://user-images.githubusercontent.com/16220722/99257535-db1adc80-281f-11eb-9f04-0ba8e25a024e.png">

</details>

### What issues does this PR fix or reference?

resolves https://github.com/eclipse/che/issues/13852

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
