### PR TITLE
Hide "Factories" menu item in sidenav bar

### DIFF
--- a/src/components/branding/branding.json
+++ b/src/components/branding/branding.json
@@ -36,7 +36,7 @@
   "configuration": {
     "menu": {
       "disabled": [
-        "organizations"
+        "organizations", "factories"
       ]
     },
     "features": {


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

Even though "Factories" menu item in left navigation bar is disabled, this PR updates the branding configuration to disable this menu item in downstream projects as well because persistent factories are based on workspace config and currently this feature doesn't work.

However, factory loading flow `/f?url=` still works.

### What issues does this PR fix or reference?

https://issues.redhat.com/browse/CRW-1383
