### PR TITLE
Use docker/login-action@v1 to login to docker registries

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,10 +29,18 @@ jobs:
         buildx-version: v0.4.1
     - name: "Docker prepare"
       run: docker image prune -a -f
-    - name: "Docker Quay.io Login"
-      run:  docker login -u "${{ secrets.QUAY_USERNAME }}" -p "${{ secrets.QUAY_PASSWORD }}" quay.io
-    - name: "Docker docker.io Login"
-      run:  docker login -u "${{ secrets.DOCKERHUB_USERNAME }}" -p "${{ secrets.DOCKERHUB_PASSWORD }}" docker.io
+    - name: 'Docker quay.io Login'
+      uses: docker/login-action@v1
+      with:
+        registry: quay.io
+        username: ${{ secrets.QUAY_USERNAME }}
+        password: ${{ secrets.QUAY_PASSWORD }}
+    - name: 'Docker docker.io Login'
+      uses: docker/login-action@v1
+      with:
+        registry: docker.io
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_PASSWORD }}
     - name: "Docker build with cache"
       uses: nick-invision/retry@v1
       with:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -110,8 +110,11 @@ jobs:
             bash ${GITHUB_WORKSPACE}/${DIR_CHE}/dockerfiles/che/build.sh --skip-tests --tag:${IMAGE_VERSION} --organization:${ORGANIZATION} --build-arg:"CHE_DASHBOARD_VERSION=${IMAGE_VERSION},CHE_DASHBOARD_ORGANIZATION=${ORGANIZATION},CHE_WORKSPACE_LOADER_VERSION=${CHE_VERSION}"
       -
         name: 'Docker docker.io Login'
-        run: |
-          docker login -u "${{ secrets.DOCKERHUB_MAXURA_USERNAME }}" -p "${{ secrets.DOCKERHUB_MAXURA_PASSWORD }}" docker.io
+        uses: docker/login-action@v1
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_MAXURA_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_MAXURA_PASSWORD }}
       -
         name: 'Docker Push'
         run: |


### PR DESCRIPTION
This PR fixes github workflows by using docker/login-action@v1 instead of shell login.