### PR TITLE
Propagate Che Server error on resolving factory failure

### DIFF
--- a/src/components/api/che-factory.factory.ts
+++ b/src/components/api/che-factory.factory.ts
@@ -464,10 +464,16 @@ export class CheFactory {
     }).catch((response: ng.IHttpResponse<any>) => {
       let errorMessage: string;
       if (response.status === -1 || (!response.status && !response.statusText)) {
+        // request is interrupted, there is even no response
         errorMessage = `Failed to fetch the devfile due to network issues while requesting "${response.config.url}".`;
+      } else if (response.data && response.data.message) {
+        // Che Server error that should be self-descriptive
+        errorMessage = response.data.message;
       } else {
+        // The error is not from Che Server, so response may be in html format that we're not able to handle.
+        // Displaying just a response code and URL.
         const delimiter = response.status && response.statusText ? ' ' : '';
-        errorMessage = `Failed to fetch the devfile due to "${response.status}${delimiter}${response.statusText}" returned by "${response.config.url}"`;
+        errorMessage = `Failed to fetch the devfile due to "${response.status}${delimiter}${response.statusText}" returned by "${response.config.url}. See browser logs for more details"`;
       }
       console.error(errorMessage, response);
       return this.$q.reject(errorMessage);


### PR DESCRIPTION
### What does this PR do?
Makes Dashboard propagate Che Server error on resolving factory failure;
![Screenshot_20201208_153905](https://user-images.githubusercontent.com/5887312/101491094-ff279480-396b-11eb-9de9-bdbbcde2dc0e.png)

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/18164

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
N/A

#### Docs PR
N/A