### PR TITLE
Multiarch build support by docker buildx

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,30 +7,110 @@ on:
         description: 'The version that is going to be released. Should be in format 7.y.z'
         required: true
         default: '7.y.z'
+
+env:
+  IMAGE: quay.io/eclipse/che-dashboard
+
 jobs:
-  build:
-    name: Create Release
-    runs-on: ubuntu-latest
+
+  build-images:
+    runs-on: ubuntu-18.04
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [amd64,arm64,ppc64le,s390x]
+    outputs:
+      amd64: ${{ steps.result.outputs.amd64 }}
+      arm64: ${{ steps.result.outputs.arm64 }}
+      ppc64le: ${{ steps.result.outputs.ppc64le }}
+      s390x: ${{ steps.result.outputs.s390x }}
     steps:
-      - uses: actions/checkout@v2
-      - name: Login to docker.io
+      -
+        name: "Checkout Che Dashboard source code"
+        uses: actions/checkout@v2
+      -
+        name: "Set up QEMU"
+        uses: docker/setup-qemu-action@v1
+      -
+        name: "Set up Docker Buildx ${{ matrix.arch }}"
+        uses: docker/setup-buildx-action@v1
+      -
+        name: "Docker quay.io Login"
         uses: docker/login-action@v1
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
-          registry: docker.io
-      - name: Login to quay.io
-        uses: docker/login-action@v1
-        with:
+          registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
+      -
+        name: "Build and push ${{ matrix.arch }}"
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./apache.Dockerfile
+          platforms: linux/${{ matrix.arch }}
+          push: true
+          tags: ${{ env.IMAGE }}:${{ github.event.inputs.version }}-${{ matrix.arch }}
+      -
+        id: result
+        name: "Build result outputs version"
+        if: ${{ success() }}
+        run: echo "::set-output name=${{ matrix.arch }}::${{ github.event.inputs.version }}-${{ matrix.arch }}"
+
+  create-manifest:
+    needs: build-images
+    runs-on: ubuntu-18.04
+    steps:
+      -
+        name: "Docker quay.io Login"
+        uses: docker/login-action@v1
+        with:
           registry: quay.io
-      - name: Create Release
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+      -
+        name: "Create and push manifest"
+        run: |
+          AMD64_VERSION="${{ needs['build-images'].outputs.amd64 }}"
+          ARM64_VERSION="${{ needs['build-images'].outputs.arm64 }}"
+          PPC64LE_VERSION="${{ needs['build-images'].outputs.ppc64le }}"
+          S390X_VERSION="${{ needs['build-images'].outputs.s390x }}"
+
+          if [[ -z "$AMD64_VERSION" || \
+               -z "$ARM64_VERSION" || \
+               -z "$PPC64LE_VERSION" || \
+               -z "$S390X_VERSION" ]]; then
+            echo "[!] The job 'build-images' fails on some of the architectures. Can't create complete manifest.";
+            exit 1;
+          fi
+
+          AMEND=""
+          AMEND+=" --amend ${{ env.IMAGE }}:$AMD64_VERSION";
+          AMEND+=" --amend ${{ env.IMAGE }}:$ARM64_VERSION";
+          AMEND+=" --amend ${{ env.IMAGE }}:$PPC64LE_VERSION";
+          AMEND+=" --amend ${{ env.IMAGE }}:$S390X_VERSION";
+
+          docker manifest create ${{ env.IMAGE }}:${{ github.event.inputs.version }} $AMEND
+          docker manifest push ${{ env.IMAGE }}:${{ github.event.inputs.version }}
+      -
+        id: result
+        name: "Manifest result"
+        if: ${{ success() }}
+        run: echo "Manifest was created and pushed successfully"
+
+  tag-release:
+    needs: create-manifest
+    runs-on: ubuntu-18.04
+    steps:
+      -
+        name: "Checkout Che Dashboard source code"
+        uses: actions/checkout@v2
+      -
+        name: "Tag release"
         run: |
           git config --global user.name "Mykhailo Kuznietsov"
           git config --global user.email "mkuznets@redhat.com"
           export GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
-          /bin/bash make-release.sh --version ${{ github.event.inputs.version }} --trigger-release
+          /bin/bash make-release.sh --version ${{ github.event.inputs.version }} --tag-release
       - name: Create MM message
         run: |
           echo "{\"text\":\":building_construction: Che Dashboard ${{ github.event.inputs.version }} has been released: https://quay.io/eclipse/che-dashboard:${{ github.event.inputs.version }}\"}" > mattermost.json

--- a/make-release.sh
+++ b/make-release.sh
@@ -12,15 +12,15 @@
 # Used to create branch/tag, update VERSION files 	
 # and and trigger release by force pushing changes to the release branch 	
 
-# set to 1 to actually trigger changes in the release branch	
-TRIGGER_RELEASE=0 	
+# set to 1 to actually tag the changes to the release branch	
+TAG_RELEASE=0 	
 NOCOMMIT=0	
 
 while [[ "$#" -gt 0 ]]; do	
   case $1 in	
-    '-t'|'--trigger-release') TRIGGER_RELEASE=1; NOCOMMIT=0; shift 0;;	
+    '-t'|'--tag-release') TAG_RELEASE=1; NOCOMMIT=0; shift 0;;	
     '-v'|'--version') VERSION="$2"; shift 1;;	
-    '-n'|'--no-commit') NOCOMMIT=1; TRIGGER_RELEASE=0; shift 0;;	
+    '-n'|'--no-commit') NOCOMMIT=1; TAG_RELEASE=0; shift 0;;	
   esac	
   shift 1	
 done	
@@ -59,16 +59,14 @@ bump_version () {
 
 usage ()	
 {	
-  echo "Usage: $0 --version [VERSION TO RELEASE] [--trigger-release]"	
-  echo "Example: $0 --version 7.7.0 --trigger-release"; echo	
+  echo "Usage: $0 --version [VERSION TO RELEASE] [--tag-release]"	
+  echo "Example: $0 --version 7.7.0 --tag-release"; echo	
 }	
 
 if [[ ! ${VERSION} ]]; then	
   usage	
   exit 1	
 fi	
-
-QUAY_REPO="quay.io/eclipse/che-dashboard:${VERSION}"	
 
 # derive branch from version	
 BRANCH=${VERSION%.*}.x	
@@ -105,12 +103,7 @@ if [[ ${NOCOMMIT} -eq 0 ]]; then
   git push origin "${BRANCH}"	
 fi	
 
-if [[ $TRIGGER_RELEASE -eq 1 ]]; then	
-  # push new branch to release branch to trigger CI build	
-  git checkout "${BRANCH}"	
-  docker build -t "${QUAY_REPO}" -f apache.Dockerfile .	
-  docker push "${QUAY_REPO}"	
-
+if [[ $TAG_RELEASE -eq 1 ]]; then	
   # tag the release	
   git checkout "${BRANCH}"	
   git tag "${VERSION}"	


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Enables docker buildx support in GitHub Actions release job to build and publish multiarch docker image.

### What issues does this PR fix or reference?
This refers to [#17124](https://github.com/eclipse/che/issues/17124). 




