### PR TITLE
 Build next react in the same manner as it used to be

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,15 +11,15 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - main-react
 jobs:
   docker-build:
     runs-on: ubuntu-18.04
     strategy:
       fail-fast: false
     env:
-      IMAGE_FULL: quay.io/eclipse/che-dashboard:next
-      CACHE_IMAGE_FULL: docker.io/cheincubator/che-dashboard:cache
+      IMAGE_FULL: quay.io/eclipse/che-dashboard:next-react
+      CACHE_IMAGE_FULL: docker.io/cheincubator/che-dashboard:cache-react
     steps:
     - uses: actions/checkout@v2
       name: Checkout che-dashboard source code

--- a/apache.Dockerfile
+++ b/apache.Dockerfile
@@ -21,5 +21,5 @@ COPY . /dashboard/
 RUN yarn compile
 
 FROM ${CHE_DASHBOARD_IMAGE}:${CHE_DASHBOARD_VERSION}
-RUN mkdir -p /usr/local/apache2/htdocs/dashboard
-COPY --from=builder /dashboard/build /usr/local/apache2/htdocs/dashboard
+RUN mkdir -p /usr/local/apache2/htdocs/dashboard/next
+COPY --from=builder /dashboard/build /usr/local/apache2/htdocs/dashboard/next


### PR DESCRIPTION
### What does this PR do?
For time being, until react based Dashboard is not moved to the master, it's needed to return back `/next` suffix for target directory to make it compatible with Che master branch.
Also, we need to keep building the latest React Based Dashboard, and this PR does it as well. Note that in che-incubator it's already disabled by https://github.com/che-incubator/che-dashboard-next/commit/b1ba50279fbb481963b159e778d4cc3699a3d9f1

### What issues does this PR fix or reference?
N/A
