### PR TITLE
Add banner that triggers when websockets arent available

### DIFF
--- a/src/Layout/index.tsx
+++ b/src/Layout/index.tsx
@@ -24,6 +24,7 @@ import { KeycloakAuthService } from '../services/keycloak/auth';
 import { IssuesReporterService } from '../services/bootstrap/issuesReporter';
 import { ErrorReporter } from './ErrorReporter';
 import { IssueComponent } from './ErrorReporter/Issue';
+import WebSocketBannerAlert from '../components/WebSocketBannerAlert';
 
 const THEME_KEY = 'theme';
 const IS_MANAGED_SIDEBAR = false;
@@ -152,6 +153,7 @@ export class Layout extends React.PureComponent<Props, State> {
         }
         isManagedSidebar={IS_MANAGED_SIDEBAR}
       >
+        <WebSocketBannerAlert />
         {this.props.children}
       </Page>
     );

--- a/src/components/WebSocketBannerAlert/__tests__/WebSocketBannerAlert.spec.tsx
+++ b/src/components/WebSocketBannerAlert/__tests__/WebSocketBannerAlert.spec.tsx
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2018-2020 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import React from 'react';
+import { container } from '../../../inversify.config';
+import WebSocketBannerAlert from '../';
+import { CheWorkspaceClient } from '../../../services/cheWorkspaceClient';
+import { Provider } from 'react-redux';
+import { FakeStoreBuilder } from '../../../store/__mocks__/storeBuilder';
+import { BrandingData } from '../../../services/bootstrap/branding.constant';
+import { render, RenderResult } from '@testing-library/react';
+
+const failingWebSocketName = 'Failing websocket';
+const failingMessage = 'WebSocket connections are failing';
+
+class mockCheWorkspaceClient extends CheWorkspaceClient {
+  get failingWebSockets() { return [failingWebSocketName]; }
+}
+
+const store = new FakeStoreBuilder().withBranding({
+  docs: {
+    webSocketTroubleshooting: 'http://sample_documentation'
+  }
+} as BrandingData).build();
+
+describe('WebSocketBannerAlert component', () => {
+  it('should show error message when error found before mounting', () => {
+    container.rebind(CheWorkspaceClient).to(mockCheWorkspaceClient).inSingletonScope();
+    const component = renderComponent(<WebSocketBannerAlert />);
+    container.rebind(CheWorkspaceClient).to(CheWorkspaceClient).inSingletonScope();
+    expect(component.getAllByText(failingMessage, {
+      exact: false
+    }).length).toEqual(1);
+  });
+
+  it('should show error message when error found after mounting', () => {
+    const comp = (
+      <Provider store={store}>
+        <WebSocketBannerAlert />
+      </Provider>
+    );
+    const component = renderComponent(comp);
+    expect(component.queryAllByText(failingMessage, {
+      exact: false
+    })).toEqual([]);
+    container.rebind(CheWorkspaceClient).to(mockCheWorkspaceClient).inSingletonScope();
+    component.rerender(comp);
+    container.rebind(CheWorkspaceClient).to(CheWorkspaceClient).inSingletonScope();
+    expect(component.getAllByText(failingMessage, {
+      exact: false
+    }).length).toEqual(1);
+  });
+
+  it('should not show error message if none is present', () => {
+    const component = renderComponent(<WebSocketBannerAlert />);
+    expect(component.queryAllByText(failingMessage, {
+      exact: false
+    })).toEqual([]);
+  });
+
+});
+
+function renderComponent(
+  component: React.ReactElement
+): RenderResult {
+  return render(
+    <Provider store={store}>
+      {component}
+    </Provider>
+  );
+}

--- a/src/components/WebSocketBannerAlert/index.tsx
+++ b/src/components/WebSocketBannerAlert/index.tsx
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2018-2020 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { Banner } from '@patternfly/react-core';
+import React from 'react';
+import { connect, ConnectedProps } from 'react-redux';
+import { container } from '../../inversify.config';
+import { CheWorkspaceClient } from '../../services/cheWorkspaceClient';
+import { AppState } from '../../store';
+
+type Props = MappedProps & {};
+
+type State = {
+  erroringWebSockets: string[];
+};
+
+class WebSocketBannerAlert extends React.PureComponent<Props, State> {
+  private readonly cheWorkspaceClient: CheWorkspaceClient;
+
+  constructor(props: Props) {
+    super(props);
+    this.cheWorkspaceClient = container.get(CheWorkspaceClient);
+    this.state = {
+      erroringWebSockets: this.cheWorkspaceClient.failingWebSockets,
+    };
+  }
+
+  public componentWillUnmount() {
+    this.cheWorkspaceClient.removeWebSocketFailedListener();
+  }
+
+  public componentDidMount() {
+    this.cheWorkspaceClient.onWebSocketFailed(() => {
+      this.setState({
+        erroringWebSockets: this.cheWorkspaceClient.failingWebSockets,
+      });
+    });
+  }
+
+  render() {
+    if (this.state.erroringWebSockets.length === 0) {
+      return null;
+    }
+
+    const webSocketTroubleshootingDocs = this.props.brandingStore.data.docs
+      .webSocketTroubleshooting;
+    return (
+      <Banner className="pf-u-text-align-center" variant="warning">
+        WebSocket connections are failing. Refer to &quot;
+        <a href={webSocketTroubleshootingDocs} rel="noreferrer" target="_blank">
+          Network Troubleshooting
+        </a>&quot;
+        in the user guide.
+      </Banner>
+    );
+  }
+}
+
+const mapStateToProps = (state: AppState) => ({
+  brandingStore: state.branding,
+});
+
+const connector = connect(mapStateToProps);
+
+type MappedProps = ConnectedProps<typeof connector>;
+export default connector(WebSocketBannerAlert);

--- a/yarn.lock
+++ b/yarn.lock
@@ -467,9 +467,9 @@
   integrity sha512-KnnnDpnxxK0TBgR0Ux3oOYCvmCv6d4cRA+1j9wiLkaJighCqgCUaxnHWXEfolYbRq1+o/sfsxN+BxRDuF+H8wQ==
 
 "@eclipse-che/workspace-client@^0.0.1-1608729566":
-  version "0.0.1-1608729566"
-  resolved "https://registry.yarnpkg.com/@eclipse-che/workspace-client/-/workspace-client-0.0.1-1608729566.tgz#833fd4ce3b32672a9329973ad10070c4bb78a8ab"
-  integrity sha512-yCWGK+iv3Zs8bLc+3oNho6NEiZ6deCs7MS1/oIGV/Z+edhcmzXWuEWE7BBBlV1kjsx63bnPuSXz4R/JLmD5v3Q==
+  version "0.0.1-1610629049"
+  resolved "https://registry.yarnpkg.com/@eclipse-che/workspace-client/-/workspace-client-0.0.1-1610629049.tgz#fd34b7b3f22bc969570c391cd4683c05782c2c9f"
+  integrity sha512-GF/1b3F/BsrqeF+BZ1QXZrEpQFLoiztD6QTQw0rcGBIr04K6IL+QpI+i3z6MbaI59yWvxEkhA/VL2oFTprEyyA==
   dependencies:
     "@eclipse-che/api" "^7.0.0-beta-4.0"
     axios "0.20.0"


### PR DESCRIPTION
Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
This PR adds a new component called WebSocketBannerAlert that is used for showing the banner alert when a WebSocket is failing to connect

Pre-req PRs:
https://github.com/che-incubator/che-dashboard-next/pull/109
https://github.com/eclipse/che-dashboard/pull/127
https://github.com/eclipse/che-workspace-client/pull/50

### What issues does this PR fix or reference?

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->
https://github.com/eclipse/che/issues/18490

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
Added WebSocket troubleshooting banner that triggers when WebSockets are not available

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
