### PR TITLE
Remove websocket context from branding

### DIFF
--- a/src/services/bootstrap/branding.constant.ts
+++ b/src/services/bootstrap/branding.constant.ts
@@ -16,7 +16,6 @@ export type BrandingData = {
   productVersion?: string;
   logoTextFile: string;
   logoFile: string;
-  websocketContext: string;
   helpPath: string;
   helpTitle: string;
   supportEmail: string;
@@ -52,7 +51,6 @@ export const BRANDING_DEFAULT: BrandingData = {
   // in case customization is needed these files should be defined in
   // favicon: '/assets/branding/favicon.ico',
   // loader: '/assets/branding/loader.svg',
-  websocketContext: '/api/websocket',
   helpPath: 'https://www.eclipse.org/che/',
   helpTitle: 'Community',
   supportEmail: 'che-dev@eclipse.org',


### PR DESCRIPTION
### What does this PR do?
Remove websocket context from branding.
Its usage is already removed in https://github.com/che-incubator/che-dashboard-next/pull/112/files#diff-8fd62774061c06dca4b4214eb5a933c2338f87f63268c342f8ccee358f3a92e3R125
but that time I forget to remove it from the branding :man_facepalming:  

### What issues does this PR fix or reference?
N/A