### PR TITLE
Provide refresh token arg to che workspace client

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -467,9 +467,9 @@
   integrity sha512-KnnnDpnxxK0TBgR0Ux3oOYCvmCv6d4cRA+1j9wiLkaJighCqgCUaxnHWXEfolYbRq1+o/sfsxN+BxRDuF+H8wQ==
 
 "@eclipse-che/workspace-client@^0.0.1-1608729566":
-  version "0.0.1-1610629049"
-  resolved "https://registry.yarnpkg.com/@eclipse-che/workspace-client/-/workspace-client-0.0.1-1610629049.tgz#fd34b7b3f22bc969570c391cd4683c05782c2c9f"
-  integrity sha512-GF/1b3F/BsrqeF+BZ1QXZrEpQFLoiztD6QTQw0rcGBIr04K6IL+QpI+i3z6MbaI59yWvxEkhA/VL2oFTprEyyA==
+  version "0.0.1-1611344228"
+  resolved "https://registry.yarnpkg.com/@eclipse-che/workspace-client/-/workspace-client-0.0.1-1611344228.tgz#983eb6ca71717ee665dff001006ab07815734e4a"
+  integrity sha512-Ru658debzMS+JZfiZC3Jr5y3DQSK0JAp6/dq81PmZm07UPwg0FdFiOH6lN/lr8yYJTu+Hl0+4rOhCS3SSwvJPA==
   dependencies:
     "@eclipse-che/api" "^7.0.0-beta-4.0"
     axios "0.20.0"


### PR DESCRIPTION
Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
This PR in conjunction with https://github.com/eclipse/che-workspace-client/pull/51 makes it so that you can refresh a token when a websocket is reconnecting. That way, the token used when establishing the websocket connection is always valid. It also removes websocket context.

### What issues does this PR fix or reference?
Part of https://github.com/eclipse/che/issues/18490#issuecomment-760079244

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
Fix an issue where tokens aren't refreshed before websockets are reconnected


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
