### PR TITLE
Add in ability to add warning banner

### DIFF
--- a/src/Layout/index.tsx
+++ b/src/Layout/index.tsx
@@ -24,7 +24,7 @@ import { KeycloakAuthService } from '../services/keycloak/auth';
 import { IssuesReporterService } from '../services/bootstrap/issuesReporter';
 import { ErrorReporter } from './ErrorReporter';
 import { IssueComponent } from './ErrorReporter/Issue';
-import WebSocketBannerAlert from '../components/WebSocketBannerAlert';
+import { BannerAlert } from '../components/BannerAlert';
 
 const THEME_KEY = 'theme';
 const IS_MANAGED_SIDEBAR = false;
@@ -153,7 +153,7 @@ export class Layout extends React.PureComponent<Props, State> {
         }
         isManagedSidebar={IS_MANAGED_SIDEBAR}
       >
-        <WebSocketBannerAlert />
+        <BannerAlert />
         {this.props.children}
       </Page>
     );

--- a/src/components/BannerAlert/WarningBanner/__tests__/WarningBanner.spec.tsx
+++ b/src/components/BannerAlert/WarningBanner/__tests__/WarningBanner.spec.tsx
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2018-2020 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import React from 'react';
+import WarningBanner from '..';
+import { Provider } from 'react-redux';
+import { FakeStoreBuilder } from '../../../../store/__mocks__/storeBuilder';
+import { BrandingData } from '../../../../services/bootstrap/branding.constant';
+import { render, RenderResult } from '@testing-library/react';
+import { Store } from 'redux';
+
+const scheduledMaintenance = 'Scheduled maintenance';
+const store = new FakeStoreBuilder().withBranding({
+  header: {
+    warning: scheduledMaintenance
+  }
+} as BrandingData).build();
+
+describe('WarningBanner component', () => {
+  it('should show header warning message when', () => {
+    const component = renderComponent(<WarningBanner />, store);
+    expect(component.queryAllByText(scheduledMaintenance, {
+      exact: false
+    }).length).toEqual(1);
+  });
+
+  it('should not show header warning message when no header was present', () => {
+    const component = renderComponent(<WarningBanner />, new FakeStoreBuilder().build());
+    expect(component.queryAllByText(scheduledMaintenance, {
+      exact: false
+    })).toEqual([]);
+  });
+
+});
+
+function renderComponent(
+  component: React.ReactElement,
+  store: Store<any, any>
+): RenderResult {
+  return render(
+    <Provider store={store}>
+      {component}
+    </Provider>
+  );
+}

--- a/src/components/BannerAlert/WarningBanner/index.tsx
+++ b/src/components/BannerAlert/WarningBanner/index.tsx
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2018-2020 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { Banner } from '@patternfly/react-core';
+import React from 'react';
+import { connect, ConnectedProps } from 'react-redux';
+import { AppState } from '../../../store';
+
+type Props = MappedProps & {};
+
+type State = {};
+
+class WarningBannerAlert extends React.PureComponent<Props, State> {
+
+  render() {
+    const warningMessage = this.props.brandingStore.data.header?.warning;
+    if (!warningMessage) {
+      return null;
+    }
+
+    return (
+      <Banner className="pf-u-text-align-center" variant="warning">
+        {warningMessage}
+      </Banner>
+    );
+  }
+}
+
+const mapStateToProps = (state: AppState) => ({
+  brandingStore: state.branding,
+});
+
+const connector = connect(mapStateToProps);
+
+type MappedProps = ConnectedProps<typeof connector>;
+export default connector(WarningBannerAlert);

--- a/src/components/BannerAlert/WebSocketBanner/__tests__/WebSocketBanner.spec.tsx
+++ b/src/components/BannerAlert/WebSocketBanner/__tests__/WebSocketBanner.spec.tsx
@@ -11,12 +11,12 @@
  */
 
 import React from 'react';
-import { container } from '../../../inversify.config';
-import WebSocketBannerAlert from '../';
-import { CheWorkspaceClient } from '../../../services/cheWorkspaceClient';
+import { container } from '../../../../inversify.config';
+import WebSocketBanner from '..';
+import { CheWorkspaceClient } from '../../../../services/cheWorkspaceClient';
 import { Provider } from 'react-redux';
-import { FakeStoreBuilder } from '../../../store/__mocks__/storeBuilder';
-import { BrandingData } from '../../../services/bootstrap/branding.constant';
+import { FakeStoreBuilder } from '../../../../store/__mocks__/storeBuilder';
+import { BrandingData } from '../../../../services/bootstrap/branding.constant';
 import { render, RenderResult } from '@testing-library/react';
 
 const failingWebSocketName = 'Failing websocket';
@@ -32,10 +32,10 @@ const store = new FakeStoreBuilder().withBranding({
   }
 } as BrandingData).build();
 
-describe('WebSocketBannerAlert component', () => {
+describe('WebSocketBanner component', () => {
   it('should show error message when error found before mounting', () => {
     container.rebind(CheWorkspaceClient).to(mockCheWorkspaceClient).inSingletonScope();
-    const component = renderComponent(<WebSocketBannerAlert />);
+    const component = renderComponent(<WebSocketBanner />);
     container.rebind(CheWorkspaceClient).to(CheWorkspaceClient).inSingletonScope();
     expect(component.getAllByText(failingMessage, {
       exact: false
@@ -45,7 +45,7 @@ describe('WebSocketBannerAlert component', () => {
   it('should show error message when error found after mounting', () => {
     const comp = (
       <Provider store={store}>
-        <WebSocketBannerAlert />
+        <WebSocketBanner />
       </Provider>
     );
     const component = renderComponent(comp);
@@ -61,7 +61,7 @@ describe('WebSocketBannerAlert component', () => {
   });
 
   it('should not show error message if none is present', () => {
-    const component = renderComponent(<WebSocketBannerAlert />);
+    const component = renderComponent(<WebSocketBanner />);
     expect(component.queryAllByText(failingMessage, {
       exact: false
     })).toEqual([]);

--- a/src/components/BannerAlert/WebSocketBanner/index.tsx
+++ b/src/components/BannerAlert/WebSocketBanner/index.tsx
@@ -13,9 +13,9 @@
 import { Banner } from '@patternfly/react-core';
 import React from 'react';
 import { connect, ConnectedProps } from 'react-redux';
-import { container } from '../../inversify.config';
-import { CheWorkspaceClient } from '../../services/cheWorkspaceClient';
-import { AppState } from '../../store';
+import { container } from '../../../inversify.config';
+import { CheWorkspaceClient } from '../../../services/cheWorkspaceClient';
+import { AppState } from '../../../store';
 
 type Props = MappedProps & {};
 
@@ -23,7 +23,7 @@ type State = {
   erroringWebSockets: string[];
 };
 
-class WebSocketBannerAlert extends React.PureComponent<Props, State> {
+class WebSocketBanner extends React.PureComponent<Props, State> {
   private readonly cheWorkspaceClient: CheWorkspaceClient;
 
   constructor(props: Props) {
@@ -72,4 +72,4 @@ const mapStateToProps = (state: AppState) => ({
 const connector = connect(mapStateToProps);
 
 type MappedProps = ConnectedProps<typeof connector>;
-export default connector(WebSocketBannerAlert);
+export default connector(WebSocketBanner);

--- a/src/components/BannerAlert/index.tsx
+++ b/src/components/BannerAlert/index.tsx
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2018-2020 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import React from 'react';
+import WarningBanner from './WarningBanner';
+import WebSocketBanner from './WebSocketBanner';
+
+type Props = {};
+
+type State = {
+  bannerAlerts: React.ReactElement[];
+};
+
+export class BannerAlert extends React.PureComponent<Props, State> {
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      bannerAlerts: [
+        <WebSocketBanner key='WebSocketBannerAlert'></WebSocketBanner>,
+        <WarningBanner key='WarningBanner'></WarningBanner>
+      ]
+    };
+  }
+
+  render() {
+    const banners = this.state.bannerAlerts;
+    return (
+      <div>
+        {
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          banners.map(banner => <div key={banner.key!}>{banner}</div>)
+        }
+      </div>
+    );
+  }
+}

--- a/src/services/bootstrap/branding.constant.ts
+++ b/src/services/bootstrap/branding.constant.ts
@@ -21,6 +21,11 @@ export type BrandingData = {
   supportEmail: string;
   docs: BrandingDocs;
   configuration: BrandingConfiguration;
+  header?: BrandingHeader;
+}
+
+export type BrandingHeader = {
+  warning: string;
 }
 
 export type BrandingDocs = {


### PR DESCRIPTION
Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
This PR adds an optional warning banner and allows you to show multiple banners at once. I'm not entirely sure if it makes sense to allow the product.json to render the warning text as html as requested, otherwise it could open up the dashboard to an xss attack

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/18769

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
Add in the ability to add warning banner on Che Dashboard

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
