### PR TITLE
Upgrade dash-licenses to the latest master

### DIFF
--- a/license-tool/licenseTool.Dockerfile
+++ b/license-tool/licenseTool.Dockerfile
@@ -14,8 +14,8 @@ RUN microdnf install -y git
 
 ARG MAVEN_VERSION=3.6.3
 ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
-# https://github.com/eclipse/dash-licenses/commits Jul 21, 2020
-ARG DASH_LICENSE_REV=b90756084cac437443b48f1d48edab6e991f2697
+# https://github.com/eclipse/dash-licenses/commits Jan 25, 2021
+ARG DASH_LICENSE_REV=88b29e82ba9d4b83f86e3842fc942e2513666534
 
 RUN mkdir -p /usr/local/apache-maven /usr/local/apache-maven/ref \
   && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz \

--- a/license-tool/run.sh
+++ b/license-tool/run.sh
@@ -10,10 +10,10 @@ if [ ! -d ${PWD}/.deps/tmp ]; then
     mkdir ${PWD}/.deps/tmp
 fi
 
-if [ ! -f ${PWD}/.deps/tmp/DEPENDENCIES ]; then
-    touch ${PWD}/.deps/tmp/DEPENDENCIES
-    chmod 666 ${PWD}/.deps/tmp/DEPENDENCIES
-fi
+# clean up old DEPENDENCIES to make sure that the out-dated version is not used
+rm -f ${PWD}/.deps/tmp/DEPENDENCIES
+touch ${PWD}/.deps/tmp/DEPENDENCIES
+chmod 666 ${PWD}/.deps/tmp/DEPENDENCIES
 
 docker run --rm -t -v ${PWD}/yarn.lock:/workspace/yarn.lock  \
        -v ${PWD}/package.json:/workspace/package.json  \

--- a/license-tool/src/entrypoint.sh
+++ b/license-tool/src/entrypoint.sh
@@ -11,7 +11,10 @@ if [ ! -f $DASH_LICENSES ]; then
     exit 1
 fi
 
-node dash-licenses/yarn/index.js | java -jar $DASH_LICENSES -
 echo "The DEPENDENCIES file is being generated..."
+node dash-licenses/yarn/index.js | java -jar $DASH_LICENSES -summary DEPENDENCIES -
+echo "Done."
+
+echo "The dev.md and prod.md files are being generated..."
 node ./bump-deps.js
 echo "Done."


### PR DESCRIPTION
### What does this PR do?
It makes dash-licenses more stable and sanitize-html/ from https://github.com/eclipse/che-dashboard/pull/152 can be resolved without CQ :tada: 

### What issues does this PR fix or reference?
N/A 
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
