### PR TITLE
Wrap dashboard pages with error boundary

### DIFF
--- a/src/Layout/ErrorBoundary/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/src/Layout/ErrorBoundary/__tests__/__snapshots__/index.spec.tsx.snap
@@ -1,0 +1,72 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Error boundary should catch an error thrown inside a component 1`] = `
+<section
+  className="pf-c-page__main-section pf-m-light pf-m-fill"
+>
+  <div
+    aria-label="Danger Alert"
+    className="pf-c-alert pf-m-inline pf-m-danger"
+    data-ouia-component-id="OUIA-Generated-Alert-danger-1"
+    data-ouia-component-type="PF4/Alert"
+    data-ouia-safe={true}
+  >
+    <div
+      className="pf-c-alert__icon"
+    >
+      <svg
+        aria-hidden={true}
+        aria-labelledby={null}
+        fill="currentColor"
+        height="1em"
+        role="img"
+        style={
+          Object {
+            "verticalAlign": "-0.125em",
+          }
+        }
+        viewBox="0 0 512 512"
+        width="1em"
+      >
+        <path
+          d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+        />
+      </svg>
+    </div>
+    <h4
+      className="pf-c-alert__title"
+    >
+      <span
+        className="pf-u-screen-reader"
+      >
+        Danger alert:
+      </span>
+      Error: Uncaught exception
+    </h4>
+    <div
+      className="pf-c-alert__action-group"
+    >
+      <button
+        aria-disabled={false}
+        aria-label={null}
+        className="pf-c-button pf-m-link pf-m-inline"
+        data-ouia-component-id="OUIA-Generated-Button-link-1"
+        data-ouia-component-type="PF4/Button"
+        data-ouia-safe={true}
+        disabled={false}
+        onClick={[Function]}
+        role={null}
+        type="button"
+      >
+        View stack
+      </button>
+    </div>
+  </div>
+</section>
+`;
+
+exports[`Error boundary should render a correctly working component 1`] = `
+<span>
+  component
+</span>
+`;

--- a/src/Layout/ErrorBoundary/__tests__/index.spec.tsx
+++ b/src/Layout/ErrorBoundary/__tests__/index.spec.tsx
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2018-2020 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import React from 'react';
+import renderer from 'react-test-renderer';
+import { ErrorBoundary } from '..';
+
+class GoodComponent extends React.Component {
+  render() {
+    return <span>component</span>;
+  }
+}
+class BadComponent extends React.Component {
+  render() {
+    throw new Error('Uncaught exception');
+    return <span>component</span>;
+  }
+}
+
+function wrapComponent(componentToWrap: React.ReactNode) {
+  return (<ErrorBoundary>{componentToWrap}</ErrorBoundary>);
+}
+
+describe('Error boundary', () => {
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render a correctly working component', () => {
+    const goodComponent = <GoodComponent />;
+    const errorBoundary = wrapComponent(goodComponent);
+    expect(renderer.create(errorBoundary).toJSON()).toMatchSnapshot();
+  });
+
+  it('should catch an error thrown inside a component', () => {
+    const badComponent = <BadComponent />;
+    const errorBoundary = wrapComponent(badComponent);
+    expect(renderer.create(errorBoundary).toJSON()).toMatchSnapshot();
+  });
+
+});

--- a/src/Layout/ErrorBoundary/index.tsx
+++ b/src/Layout/ErrorBoundary/index.tsx
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2018-2020 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import React, { ErrorInfo } from 'react';
+import {
+  Alert,
+  AlertActionLink,
+  AlertVariant,
+  PageSection,
+  PageSectionVariants,
+  Text,
+  TextContent,
+  TextVariants,
+} from '@patternfly/react-core';
+
+type Props = {};
+type State = {
+  hasError: boolean;
+  error?: Error;
+  errorInfo?: ErrorInfo;
+  expanded: boolean;
+  activeItems: any;
+};
+
+export class ErrorBoundary extends React.PureComponent<Props, State> {
+
+  constructor(props: Props) {
+    super(props);
+
+    this.state = {
+      hasError: false,
+      expanded: false,
+      activeItems: {},
+    };
+  }
+
+  static getDerivedStateFromError() {
+    return {
+      hasError: true,
+    };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
+    this.setState({
+      hasError: true,
+      error,
+      errorInfo,
+    });
+  }
+
+  private handleOnClick() {
+    const expanded = !this.state.expanded;
+    this.setState({
+      expanded,
+    });
+  }
+
+  render(): React.ReactNode {
+    const { hasError, error, errorInfo, expanded } = this.state;
+
+    if (hasError) {
+      const actionTitle = expanded ? 'Hide stack' : 'View stack';
+      const errorName = error?.name ? error.name : Error;
+      const errorMessage = error?.message ? ': ' + error.message : '';
+      return (
+        <PageSection
+          variant={PageSectionVariants.light}
+          isFilled={true}
+        >
+          <Alert
+            isInline
+            variant={AlertVariant.danger}
+            title={errorName + errorMessage}
+            actionLinks={
+              <React.Fragment>
+                <AlertActionLink onClick={() => this.handleOnClick()}>
+                  {actionTitle}
+                </AlertActionLink>
+              </React.Fragment>
+            }
+          >
+            {expanded && errorInfo && <TextContent>
+              <Text component={TextVariants.pre}>
+                {errorInfo.componentStack}
+              </Text>
+            </TextContent>}
+          </Alert>
+        </PageSection>
+      );
+    }
+
+    return this.props.children;
+  }
+
+}

--- a/src/Layout/Header/Tools/index.tsx
+++ b/src/Layout/Header/Tools/index.tsx
@@ -358,12 +358,7 @@ export class HeaderTools extends React.PureComponent<Props, State> {
     const userEmail = this.getEmail();
     const username = this.getUsername();
     const imageUrl = userEmail ? gravatarUrl(userEmail, { default: 'retro' }) : '';
-    const avatar = <Avatar src={imageUrl} alt='Avatar image' />;
-
-    const userToggleButton = this.buildUserToggleButton();
-    const userDropdownItems = this.buildUserDropdownItems();
-
-    const infoDropdownItems = this.buildInfoDropdownItems();
+    const isUserAuthenticated = !!userEmail;
 
     const branding = this.props.branding.data;
     return (
@@ -374,22 +369,24 @@ export class HeaderTools extends React.PureComponent<Props, State> {
               <ApplicationLauncher
                 onToggle={() => this.onInfoDropdownToggle()}
                 isOpen={isInfoDropdownOpen}
-                items={infoDropdownItems}
+                items={this.buildInfoDropdownItems()}
                 aria-label='info button'
                 position='right'
                 toggleIcon={<QuestionCircleIcon alt='' />}
               />
-              <Dropdown
-                isPlain
-                position='right'
-                onSelect={() => this.onUsernameSelect()}
-                isOpen={isUsernameDropdownOpen}
-                toggle={userToggleButton}
-                dropdownItems={userDropdownItems}
-              />
+              {isUserAuthenticated &&
+                <Dropdown
+                  isPlain
+                  position='right'
+                  onSelect={() => this.onUsernameSelect()}
+                  isOpen={isUsernameDropdownOpen}
+                  toggle={this.buildUserToggleButton()}
+                  dropdownItems={this.buildUserDropdownItems()}
+                />}
             </PageHeaderToolsItem>
           </PageHeaderToolsGroup>
-          {avatar}
+          {isUserAuthenticated &&
+            <Avatar src={imageUrl} alt='Avatar image' />}
         </PageHeaderTools>
         <AboutModal
           isOpen={isModalOpen}

--- a/src/Layout/index.tsx
+++ b/src/Layout/index.tsx
@@ -25,6 +25,7 @@ import { IssuesReporterService } from '../services/bootstrap/issuesReporter';
 import { ErrorReporter } from './ErrorReporter';
 import { IssueComponent } from './ErrorReporter/Issue';
 import { BannerAlert } from '../components/BannerAlert';
+import { ErrorBoundary } from './ErrorBoundary';
 
 const THEME_KEY = 'theme';
 const IS_MANAGED_SIDEBAR = false;
@@ -154,8 +155,10 @@ export class Layout extends React.PureComponent<Props, State> {
         }
         isManagedSidebar={IS_MANAGED_SIDEBAR}
       >
-        <BannerAlert />
-        {this.props.children}
+        <ErrorBoundary>
+          <BannerAlert />
+          {this.props.children}
+        </ErrorBoundary>
       </Page>
     );
   }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -32,7 +32,7 @@ const ROOT = document.querySelector('.ui-container');
 // preload app data
 new PreloadData(store).init()
   .then(() => console.log('UD: preload data complete successfully.'))
-  .catch(error => console.log('UD: preload data failed.', error))
+  .catch(error => console.error('UD: preload data failed.', error))
   .finally(() => {
     ReactDOM.render(<Provider store={store}><App history={history} /></Provider>, ROOT);
   });

--- a/src/services/keycloak/setup.ts
+++ b/src/services/keycloak/setup.ts
@@ -75,16 +75,6 @@ export class KeycloakSetupService {
       const result = await this.testApiAttainability<che.User>(endpoint);
       this.user = result;
     } catch (e) {
-      if (this.isDevelopment) {
-        console.error('Failed to get response to API endpoint: \n' + e);
-        this.user = {
-          email: 'johndoe@test.com',
-          id: 'john-doe-id',
-          name: 'John Doe',
-          links: []
-        };
-        return;
-      }
       throw new Error('Failed to get response to API endpoint: \n' + e);
     }
   }
@@ -140,10 +130,6 @@ export class KeycloakSetupService {
       return settings;
     } catch (e) {
       if (e.response.status === 404) {
-        return;
-      }
-      if (this.isDevelopment) {
-        console.error(`Can't get Keycloak settings: ${e.response.status} ${e.response.statusText}`);
         return;
       }
 

--- a/src/services/storageTypes.ts
+++ b/src/services/storageTypes.ts
@@ -10,8 +10,6 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
-import { isDevelopment } from '../store/Environment';
-
 const DEFAULT_AVAILABLE_TYPES = '';
 
 export enum StorageTypeTitle {
@@ -22,10 +20,6 @@ export enum StorageTypeTitle {
 
 export function toTitle(type: che.WorkspaceStorageType): string {
   if (!StorageTypeTitle[type]) {
-    if (isDevelopment()) {
-      console.error(`Unknown storage type: "${type}"`);
-      return 'unknown';
-    }
     throw new Error(`Unknown storage type: "${type}"`);
   }
   return StorageTypeTitle[type];

--- a/src/services/storageTypes.ts
+++ b/src/services/storageTypes.ts
@@ -10,7 +10,7 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
-const DEFAULT_AVAILABLE_TYPES = '';
+import { isDevelopment } from '../store/Environment';
 
 export enum StorageTypeTitle {
   async = 'Asynchronous',
@@ -40,7 +40,11 @@ export function fromTitle(title: string): che.WorkspaceStorageType {
 
 export function getAvailable(settings: che.WorkspaceSettings): che.WorkspaceStorageType[] {
   if (!settings || !settings['che.workspace.storage.available_types']) {
-    return DEFAULT_AVAILABLE_TYPES.split(',') as che.WorkspaceStorageType[];
+    if (isDevelopment()) {
+      // running Dashboard in Che in dev mode needs for storage types to be stubbed
+      return ['persistent'];
+    }
+    throw new Error('Unable to get available storage types');
   }
   const availableTypes = settings['che.workspace.storage.available_types'];
   return availableTypes.split(',') as che.WorkspaceStorageType[];


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

Wrapping UD page components with error boundary to handle uncaught exceptions that may happen in runtime in components. 

**Screenshots**

<img width="1284" alt="Screenshot 2021-02-10 at 14 56 54" src="https://user-images.githubusercontent.com/16220722/107513070-5df9cc00-6bb0-11eb-92f5-7d1284081f79.png">

*expanded component stack*
<img width="1284" alt="Screenshot 2021-02-10 at 14 57 46" src="https://user-images.githubusercontent.com/16220722/107513081-6225e980-6bb0-11eb-8516-5acc1a70cdbf.png">


### What issues does this PR fix or reference?

fixes https://github.com/eclipse/che/issues/18758
