### PR TITLE
fix search params for the ide-loader tab

### DIFF
--- a/src/containers/IdeLoader.tsx
+++ b/src/containers/IdeLoader.tsx
@@ -89,8 +89,7 @@ class IdeLoaderContainer extends React.PureComponent<Props, State> {
   }
 
   private get preselectedTabKey(): IdeLoaderTab {
-    const { match: { params } } = this.props;
-    const search = params.workspaceName.split('?')[1];
+    const { history: { location: { search } } } = this.props;
     if (!search) {
       return IdeLoaderTab.Progress;
     }


### PR DESCRIPTION
Signed-off-by: Oleksii Orel <oorel@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Fix search params for the ide-loader tab.
