### PR TITLE
updated github workflows

### DIFF
--- a/.github/workflows/ci-multiarch.yaml
+++ b/.github/workflows/ci-multiarch.yaml
@@ -1,0 +1,116 @@
+#
+# Copyright (c) 2020 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+name: CI:multiarch
+
+on:
+  workflow_dispatch:
+    inputs: {}
+  # push:
+  pull_request:
+    branches:
+      - master
+
+env:
+  IMAGE: quay.io/eclipse/che-dashboard
+  CACHE_IMAGE_FULL: docker.io/cheincubator/che-dashboard:cache
+
+jobs:
+
+  build-images:
+    runs-on: ubuntu-18.04
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [amd64,arm64,ppc64le,s390x]
+    outputs:
+      amd64: ${{ steps.result.outputs.amd64 }}
+      arm64: ${{ steps.result.outputs.arm64 }}
+      ppc64le: ${{ steps.result.outputs.ppc64le }}
+      s390x: ${{ steps.result.outputs.s390x }}
+    steps:
+      -
+        name: "Checkout Che Dashboard source code"
+        uses: actions/checkout@v2
+      -
+        name: "Set up QEMU"
+        uses: docker/setup-qemu-action@v1
+      -
+        name: "Set up Docker Buildx ${{ matrix.arch }}"
+        uses: docker/setup-buildx-action@v1
+      -
+        name: "Docker quay.io Login"
+        uses: docker/login-action@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+      -
+        name: "Docker docker.io Login"
+        uses: docker/login-action@v1
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+      -
+        name: "Build and push ${{ matrix.arch }}"
+        uses: docker/build-push-action@v2
+        with:
+          cache-from: type=registry,ref=${{ env.CACHE_IMAGE_FULL }}
+          cache-to: type=registry,ref=${{ env.CACHE_IMAGE_FULL }},mode=max
+          context: .
+          file: ./apache.Dockerfile
+          platforms: linux/${{ matrix.arch }}
+          push: true
+          tags: ${{ env.IMAGE }}:${{ matrix.arch }}-next
+      -
+        id: result
+        name: "Build result outputs version"
+        if: ${{ success() }}
+        run: echo "::set-output name=${{ matrix.arch }}::${{ matrix.arch }}-next"
+
+  create-manifest:
+    if: always()
+    needs: build-images
+    runs-on: ubuntu-18.04
+    steps:
+      -
+        name: "Docker quay.io Login"
+        uses: docker/login-action@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+      -
+        name: "Create and push manifest"
+        run: |
+          AMEND=""
+          AMD64_VERSION="${{ needs['build-images'].outputs.amd64 }}"
+          if [ -n "$AMD64_VERSION" ]; then
+            AMEND+=" --amend ${{ env.IMAGE }}:$AMD64_VERSION";
+          fi
+          ARM64_VERSION="${{ needs['build-images'].outputs.arm64 }}"
+          if [ -n "$ARM64_VERSION" ]; then
+            AMEND+=" --amend ${{ env.IMAGE }}:$ARM64_VERSION";
+          fi
+          PPC64LE_VERSION="${{ needs['build-images'].outputs.ppc64le }}"
+          if [ -n "$PPC64LE_VERSION" ]; then
+            AMEND+=" --amend ${{ env.IMAGE }}:$PPC64LE_VERSION";
+          fi
+          S390X_VERSION="${{ needs['build-images'].outputs.s390x }}"
+          if [ -n "$S390X_VERSION" ]; then
+            AMEND+=" --amend ${{ env.IMAGE }}:$S390X_VERSION";
+          fi
+          if [ -z "$AMEND" ]; then
+            echo "[!] The job 'build-images' didn't provide any outputs. Can't create the manifest list."
+            exit 1;
+          fi
+          docker manifest create ${{ env.IMAGE }}:multiarch-next $AMEND
+          docker manifest push ${{ env.IMAGE }}:multiarch-next

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,9 +27,6 @@ jobs:
         name: "Checkout Che Dashboard source code"
         uses: actions/checkout@v2
       -
-        name: "Set up QEMU"
-        uses: docker/setup-qemu-action@v1
-      -
         name: "Set up Docker Buildx"
         uses: docker/setup-buildx-action@v1
       -
@@ -54,6 +51,5 @@ jobs:
           cache-to: type=registry,ref=${{ env.CACHE_IMAGE_FULL }},mode=max
           context: .
           file: ./apache.Dockerfile
-          platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
           push: true
           tags: ${{ env.IMAGE_FULL }}

--- a/apache.Dockerfile
+++ b/apache.Dockerfile
@@ -10,10 +10,14 @@
 
 FROM docker.io/node:12.20.1-alpine3.12 as builder
 
+RUN if ! [ type "yarn" &> /dev/null ]; then \
+        apk add yarn --no-cache; \
+    fi
+
 COPY package.json /dashboard/
 COPY yarn.lock /dashboard/
 WORKDIR /dashboard
-RUN yarn --network-timeout 600000 && yarn install
+RUN yarn install --network-timeout 600000
 COPY . /dashboard/
 RUN yarn compile
 


### PR DESCRIPTION

Signed-off-by: Oleksii Kurinnyi <okurinny@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

The CI workflow that utilized the Docker Build & Push Action to build multiarch image is rather unstable that prevents to propagate latest changes into next tag. Hense, the CI workflow is updated in order to build image for amd64 architecture only. 

Same time the Docker Build & Push Action used in PR workflow to build simultaneously single arch images for four platforms works well. This pull request adds new workflow intended to build a multiarch image using same approach. 

### What issues does this PR fix or reference?

https://github.com/eclipse/che/issues/19049
