### PR TITLE
Fix incorrect number of workspaces in confirmation window

### DIFF
--- a/src/Routes/index.tsx
+++ b/src/Routes/index.tsx
@@ -10,7 +10,6 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 
-import { Location } from 'history';
 import React from 'react';
 import { Redirect, Route, RouteComponentProps, Switch } from 'react-router';
 

--- a/src/pages/WorkspacesList/index.tsx
+++ b/src/pages/WorkspacesList/index.tsx
@@ -378,13 +378,18 @@ export default class WorkspacesList extends React.PureComponent<Props, State> {
     /* Update checkboxes states if workspaces list changes */
     if (prevProps.workspaces.length !== this.props.workspaces.length) {
       const selected: string[] = [];
+      const filtered: string[] = [];
       this.props.workspaces.forEach(workspace => {
         if (this.state.selected.indexOf(workspace.id) !== -1) {
           selected.push(workspace.id);
         }
+        if (this.state.filtered.indexOf(workspace.id) !== -1) {
+          filtered.push(workspace.id);
+        }
       });
       const isSelectedAll = selected.length !== 0 && selected.length === this.props.workspaces.length;
       this.setState({
+        filtered,
         isSelectedAll,
         selected,
       });


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

This PR fixes bug that causes to show in confirmation window an incorrect number of workspaces to be deleted.

### What issues does this PR fix or reference?

fixes https://github.com/eclipse/che/issues/19057
