### PR TITLE
Fix ability to refresh token on API calls

### DIFF
--- a/src/services/bootstrap/PreloadData.ts
+++ b/src/services/bootstrap/PreloadData.ts
@@ -23,7 +23,6 @@ import * as UserProfileStore from '../../store/UserProfile';
 import * as UserPreferencesStore from '../../store/UserPreferences';
 import * as UserStore from '../../store/User';
 import * as WorkspacesStore from '../../store/Workspaces';
-import { KeycloakAuthService } from '../keycloak/auth';
 import { CheWorkspaceClient } from '../cheWorkspaceClient';
 import { ResourceFetcherService } from '../resource-fetcher';
 
@@ -35,9 +34,6 @@ export class PreloadData {
 
   @lazyInject(KeycloakSetupService)
   private readonly keycloakSetup: KeycloakSetupService;
-
-  @lazyInject(KeycloakAuthService)
-  private readonly keycloakAuth: KeycloakAuthService;
 
   @lazyInject(CheWorkspaceClient)
   private readonly cheWorkspaceClient: CheWorkspaceClient;
@@ -88,7 +84,6 @@ export class PreloadData {
   }
 
   private async updateUser(): Promise<void> {
-    await this.keycloakSetup.start();
     const { requestUser, setUser } = UserStore.actionCreators;
     const user = this.keycloakSetup.getUser();
     if (user) {

--- a/src/services/cheWorkspaceClient/index.ts
+++ b/src/services/cheWorkspaceClient/index.ts
@@ -62,7 +62,6 @@ export class CheWorkspaceClient {
       }
 
       this.axios.interceptors.request.use(async config => {
-        console.log('>>> interceptor');
         await this.handleRefreshToken(VALIDITY_TIME, config);
         return config;
       });

--- a/src/services/cheWorkspaceClient/index.ts
+++ b/src/services/cheWorkspaceClient/index.ts
@@ -11,10 +11,11 @@
  */
 
 import { AxiosInstance, AxiosRequestConfig } from 'axios';
-import { injectable } from 'inversify';
+import { inject, injectable } from 'inversify';
 import WorkspaceClient, { IWorkspaceMasterApi, IRemoteAPI } from '@eclipse-che/workspace-client';
 import { KeycloakAuthService } from '../keycloak/auth';
 import { EventEmitter } from 'events';
+import { KeycloakSetupService } from '../keycloak/setup';
 
 export type WebSocketsFailedCallback = () => void;
 
@@ -37,7 +38,9 @@ export class CheWorkspaceClient {
   /**
    * Default constructor that is using resource.
    */
-  constructor() {
+  constructor(
+    @inject(KeycloakSetupService) private keycloakSetupService: KeycloakSetupService,
+  ) {
     this.baseUrl = '/api';
     this._failingWebSockets = [];
     this.webSocketEventEmitter = new EventEmitter();
@@ -53,39 +56,30 @@ export class CheWorkspaceClient {
       this.axios.defaults.headers.common = {};
     }
 
-    if (!KeycloakAuthService.sso) {
-      return;
-    }
-    let isUpdated: boolean;
-    const updateTimer = () => {
-      if (!isUpdated) {
-        isUpdated = true;
-        setTimeout(() => {
-          isUpdated = false;
-        }, 30000);
+    this.keycloakSetupService.ready.then(() => {
+      if (!KeycloakAuthService.sso) {
+        return;
       }
-    };
-    updateTimer();
-    this.axios.interceptors.request.use(async request => {
-      if (!isUpdated) {
-        updateTimer();
-        await this.handleRefreshToken(VALIDITY_TIME, request);
-      }
-      return request;
-    });
 
-    window.addEventListener('message', (event: MessageEvent) => {
-      if (event.data.startsWith('update-token:')) {
-        const receivedValue = parseInt(event.data.split(':')[1], 10);
-        const validityTime = Number.isNaN(receivedValue) ? VALIDITY_TIME : Math.ceil(receivedValue / 1000);
-        this.handleRefreshToken(validityTime);
-      }
-    }, false);
+      this.axios.interceptors.request.use(async config => {
+        console.log('>>> interceptor');
+        await this.handleRefreshToken(VALIDITY_TIME, config);
+        return config;
+      });
+
+      window.addEventListener('message', (event: MessageEvent) => {
+        if (event.data.startsWith('update-token:')) {
+          const receivedValue = parseInt(event.data.split(':')[1], 10);
+          const validityTime = Number.isNaN(receivedValue) ? VALIDITY_TIME : Math.ceil(receivedValue / 1000);
+          this.handleRefreshToken(validityTime);
+        }
+      }, false);
+    });
   }
 
-  private async handleRefreshToken(minValidity: number, request?: AxiosRequestConfig): Promise<void> {
+  private async handleRefreshToken(minValidity: number, config?: AxiosRequestConfig): Promise<void> {
     try {
-      await this.refreshToken(minValidity, request);
+      await this.refreshToken(minValidity, config);
     } catch (e) {
       console.error('Failed to refresh token.', e);
       this.redirectedToKeycloakLogin();
@@ -166,7 +160,7 @@ export class CheWorkspaceClient {
     return Array.from(this._failingWebSockets);
   }
 
-  private refreshToken(minValidity: number, request?: AxiosRequestConfig): Promise<string | Error> {
+  private refreshToken(minValidity: number, config?: AxiosRequestConfig): Promise<string | Error> {
     const { keycloak } = KeycloakAuthService;
     if (keycloak) {
       return new Promise((resolve, reject) => {
@@ -174,8 +168,8 @@ export class CheWorkspaceClient {
           if (refreshed && keycloak.token) {
             const header = 'Authorization';
             this.axios.defaults.headers.common[header] = `Bearer ${keycloak.token}`;
-            if (request) {
-              request.headers.common[header] = `Bearer ${keycloak.token}`;
+            if (config) {
+              config.headers.common[header] = `Bearer ${keycloak.token}`;
             }
           }
           resolve(keycloak.token as string);

--- a/src/services/keycloak/setup.ts
+++ b/src/services/keycloak/setup.ts
@@ -61,13 +61,18 @@ export class KeycloakSetupService {
 
   private isDevelopment: boolean;
   private user: che.User | undefined;
+  private _ready: Promise<void>;
+  private resolveReadyPromise: Function;
 
   constructor() {
     this.isDevelopment = isDevelopment();
+
+    this._ready = new Promise<void>(resolve => this.resolveReadyPromise = resolve);
   }
 
   async start(): Promise<void> {
     await this.doInitialization();
+    this.resolveReadyPromise();
 
     /* test API */
     try {
@@ -77,6 +82,10 @@ export class KeycloakSetupService {
     } catch (e) {
       throw new Error('Failed to get response to API endpoint: \n' + e);
     }
+  }
+
+  public get ready(): Promise<void> {
+    return this._ready;
   }
 
   private async doInitialization(): Promise<void> {


### PR DESCRIPTION


<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

This PR fixes the issue when API calls use an expired token. It improves the application pre-start set up so the `che-workspace-client` gets initialized in the correct order, after the keycloak adapter setup. That allows `che-workspace-client` to correctly register a request interceptor that does token refreshing.

### What issues does this PR fix or reference?

fixes https://github.com/eclipse/che/issues/19058
