### PR TITLE
Fix opening workspace details/IDE after it's created out of the current tab

### DIFF
--- a/src/containers/IdeLoader.tsx
+++ b/src/containers/IdeLoader.tsx
@@ -23,7 +23,7 @@ import { IdeLoaderTab, WorkspaceStatus } from '../services/helpers/types';
 import { AppState } from '../store';
 import { selectIsDevelopment } from '../store/Environment/selectors';
 import * as WorkspaceStore from '../store/Workspaces';
-import { selectAllWorkspaces, selectLogs, selectWorkspaceById } from '../store/Workspaces/selectors';
+import { selectAllWorkspaces, selectIsLoading, selectLogs, selectWorkspaceById } from '../store/Workspaces/selectors';
 
 type Props =
   MappedProps
@@ -124,7 +124,10 @@ class IdeLoaderContainer extends React.PureComponent<Props, State> {
   }
 
   public async componentDidMount(): Promise<void> {
-    const { allWorkspaces } = this.props;
+    const { isLoading, requestWorkspaces, allWorkspaces } = this.props;
+    if (!isLoading && allWorkspaces.length === 0) {
+      await requestWorkspaces();
+    }
     const workspace = allWorkspaces.find(workspace =>
       workspace.namespace === this.state.namespace && workspace.devfile.metadata.name === this.state.workspaceName);
     if (workspace && workspace.runtime && workspace.status === WorkspaceStatus[WorkspaceStatus.RUNNING]) {
@@ -352,6 +355,7 @@ class IdeLoaderContainer extends React.PureComponent<Props, State> {
 const mapStateToProps = (state: AppState) => ({
   workspace: selectWorkspaceById(state),
   allWorkspaces: selectAllWorkspaces(state),
+  isLoading: selectIsLoading(state),
   workspacesLogs: selectLogs(state),
   isDevelopment: selectIsDevelopment(state),
 });

--- a/src/containers/IdeLoader.tsx
+++ b/src/containers/IdeLoader.tsx
@@ -125,10 +125,12 @@ class IdeLoaderContainer extends React.PureComponent<Props, State> {
 
   public async componentDidMount(): Promise<void> {
     const { isLoading, requestWorkspaces, allWorkspaces } = this.props;
-    if (!isLoading && allWorkspaces.length === 0) {
+    let workspace = allWorkspaces.find(workspace =>
+      workspace.namespace === this.state.namespace && workspace.devfile.metadata.name === this.state.workspaceName);
+    if (!isLoading && !workspace) {
       await requestWorkspaces();
     }
-    const workspace = allWorkspaces.find(workspace =>
+    workspace = allWorkspaces.find(workspace =>
       workspace.namespace === this.state.namespace && workspace.devfile.metadata.name === this.state.workspaceName);
     if (workspace && workspace.runtime && workspace.status === WorkspaceStatus[WorkspaceStatus.RUNNING]) {
       return await this.updateIdeUrl(workspace.runtime);

--- a/src/containers/IdeLoader.tsx
+++ b/src/containers/IdeLoader.tsx
@@ -129,9 +129,9 @@ class IdeLoaderContainer extends React.PureComponent<Props, State> {
       workspace.namespace === this.state.namespace && workspace.devfile.metadata.name === this.state.workspaceName);
     if (!isLoading && !workspace) {
       await requestWorkspaces();
+      workspace = allWorkspaces.find(workspace =>
+        workspace.namespace === this.state.namespace && workspace.devfile.metadata.name === this.state.workspaceName);
     }
-    workspace = allWorkspaces.find(workspace =>
-      workspace.namespace === this.state.namespace && workspace.devfile.metadata.name === this.state.workspaceName);
     if (workspace && workspace.runtime && workspace.status === WorkspaceStatus[WorkspaceStatus.RUNNING]) {
       return await this.updateIdeUrl(workspace.runtime);
     } else if (workspace && workspace.status == WorkspaceStatus[WorkspaceStatus.ERROR]) {

--- a/src/containers/WorkspaceDetails.tsx
+++ b/src/containers/WorkspaceDetails.tsx
@@ -43,15 +43,22 @@ class WorkspaceDetailsContainer extends React.PureComponent<Props> {
       const pathname = `/workspace/${namespace}/${workspaceName}`;
       this.props.history.replace({ pathname });
     }
+  }
 
-    const workspace = this.props.allWorkspaces?.find(workspace =>
-      workspace.namespace === namespace && workspace.devfile.metadata.name === workspaceName);
+  private async init(): Promise<void> {
+    const { match: { params }, allWorkspaces, isLoading, requestWorkspaces, setWorkspaceId } = this.props;
+    if (!isLoading && allWorkspaces.length === 0) {
+      await requestWorkspaces();
+    }
+    const workspace = allWorkspaces?.find(workspace =>
+      workspace.namespace === params.namespace && workspace.devfile.metadata.name === params.workspaceName);
     if (workspace) {
-      this.props.setWorkspaceId(workspace.id);
+      setWorkspaceId(workspace.id);
     }
   }
 
   public componentDidMount(): void {
+    this.init();
     const showAlert = this.workspaceDetailsPageRef.current?.showAlert;
     this.showAlert = (title: string, variant?: AlertVariant) => {
       if (showAlert) {

--- a/src/containers/WorkspaceDetails.tsx
+++ b/src/containers/WorkspaceDetails.tsx
@@ -47,11 +47,13 @@ class WorkspaceDetailsContainer extends React.PureComponent<Props> {
 
   private async init(): Promise<void> {
     const { match: { params }, allWorkspaces, isLoading, requestWorkspaces, setWorkspaceId } = this.props;
-    if (!isLoading && allWorkspaces.length === 0) {
-      await requestWorkspaces();
-    }
-    const workspace = allWorkspaces?.find(workspace =>
+    let workspace = allWorkspaces?.find(workspace =>
       workspace.namespace === params.namespace && workspace.devfile.metadata.name === params.workspaceName);
+    if (!isLoading && !workspace) {
+      await requestWorkspaces();
+      workspace = allWorkspaces?.find(workspace =>
+        workspace.namespace === params.namespace && workspace.devfile.metadata.name === params.workspaceName);
+    }
     if (workspace) {
       setWorkspaceId(workspace.id);
     }

--- a/src/containers/__tests__/IdeLoader.spec.tsx
+++ b/src/containers/__tests__/IdeLoader.spec.tsx
@@ -14,7 +14,7 @@ import React from 'react';
 import { Action } from 'redux';
 import { Provider } from 'react-redux';
 import { AlertActionLink } from '@patternfly/react-core';
-import { RenderResult, render, screen } from '@testing-library/react';
+import { RenderResult, render, screen, waitFor } from '@testing-library/react';
 import { ROUTE } from '../../route.enum';
 import { getMockRouterProps } from '../../services/__mocks__/router';
 import { FakeStoreBuilder } from '../../store/__mocks__/storeBuilder';
@@ -131,9 +131,9 @@ describe('IDE Loader container', () => {
     jest.resetAllMocks();
   });
 
-  it('should show an error if something wrong', () => {
+  it('should show an error if something wrong', async () => {
     const namespace = 'admin3';
-    const workspaceName = 'name-wksp-4';
+    const workspaceName = 'name-wksp-46';
 
     renderComponent(
       namespace,
@@ -142,10 +142,11 @@ describe('IDE Loader container', () => {
 
     expect(startWorkspaceMock).not.toBeCalled();
     expect(requestWorkspaceMock).not.toBeCalled();
-    expect(showAlertMock).toBeCalledWith(expect.objectContaining({
+
+    await waitFor(() => expect(showAlertMock).toBeCalledWith(expect.objectContaining({
       alertVariant: 'danger',
       title: 'Failed to find the target workspace.'
-    }));
+    })));
 
     const elementHasError = screen.getByTestId('ide-loader-has-error');
     expect(elementHasError.innerHTML).toEqual('true');

--- a/src/containers/__tests__/IdeLoader.spec.tsx
+++ b/src/containers/__tests__/IdeLoader.spec.tsx
@@ -35,8 +35,10 @@ jest.mock('../../store/Workspaces/index', () => {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       requestWorkspace: (id: string): AppThunk<Action, Promise<void>> => async (): Promise<void> => { requestWorkspaceMock(); },
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      startWorkspace: (id: string): AppThunk<Action, Promise<void>> => async (): Promise<void> => { startWorkspaceMock(); }
-      ,
+      startWorkspace: (id: string): AppThunk<Action, Promise<void>> => async (): Promise<void> => { startWorkspaceMock(); },
+      requestWorkspaces: (): AppThunk<Action, Promise<void>> => async (): Promise<void> => {
+        return Promise.resolve();
+      },
     } as ActionCreators,
   };
 });

--- a/src/services/bootstrap/PreloadData.ts
+++ b/src/services/bootstrap/PreloadData.ts
@@ -57,12 +57,12 @@ export class PreloadData {
     await this.updateUser();
     await this.updateJsonRpcMasterApi();
 
+    this.updateWorkspaces();
     new ResourceFetcherService().prefetchResources(this.store.getState());
 
     const settings = await this.updateWorkspaceSettings();
     await Promise.all([
       this.updateBranding(),
-      this.updateWorkspaces(),
       this.updateInfrastructureNamespaces(),
       this.updateUserProfile(),
       this.updatePlugins(settings),


### PR DESCRIPTION
Signed-off-by: Oleksii Orel <oorel@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

This PR provides an additional API request in the case if we cannot find the target workspace in the storage. These additional requests fixed errors with opening workspace details/IDE pages after it's created out of the current tab. 
