### PR TITLE
Fix URIs for devfile icon and devfile self-link in single-host mode

### DIFF
--- a/src/services/registry/devfiles.ts
+++ b/src/services/registry/devfiles.ts
@@ -15,24 +15,35 @@ import axios from 'axios';
 // create new instance of `axios` to avoid adding an authorization header
 const axiosInstance = axios.create();
 
-function resolveIconUrl(metadata: che.DevfileMetaData, url: string): string {
+function createURL(url: string, baseUrl: string): URL {
+  // todo Remove it after fixing the relative paths for devfile registry https://github.com/eclipse/che/issues/18084
+  if (/^\/(\w+)/.test(url)) {
+    return new URL(`.${url}`, baseUrl);
+  }
+  return new URL(url, baseUrl);
+}
+
+function resolveIconUrl(metadata: che.DevfileMetaData, baseUrl: string): string {
   if (!metadata.icon || metadata.icon.startsWith('http')) {
     return metadata.icon;
   }
-  return new URL(metadata.icon, url).href;
+
+  return createURL(metadata.icon, baseUrl).href;
 }
 
-function resolveLinkSelf(metadata: che.DevfileMetaData, url: string): string {
+function resolveLinkSelf(metadata: che.DevfileMetaData, baseUrl: string): string {
   if (metadata.links.self.startsWith('http')) {
     return metadata.links.self;
   }
-  return new URL(metadata.links.self, url).href;
+
+  return createURL(metadata.links.self, baseUrl).href;
 }
 
 export async function fetchMetadata(registryUrl: string): Promise<che.DevfileMetaData[]> {
 
   try {
-    const response = await axiosInstance.get<che.DevfileMetaData[]>(registryUrl);
+    const registryIndexUrl = new URL('devfiles/index.json', registryUrl);
+    const response = await axiosInstance.get<che.DevfileMetaData[]>(registryIndexUrl.href);
 
     return response.data.map(meta => {
       meta.icon = resolveIconUrl(meta, registryUrl);
@@ -53,9 +64,7 @@ export async function fetchRegistriesMetadata(registryUrls: string): Promise<che
 
   try {
     const metadataPromises = urls.map(registryUrl => {
-      registryUrl = registryUrl[registryUrl.length - 1] === '/' ? registryUrl : registryUrl + '/';
-      const registryIndexUrl = new URL('devfiles/index.json', registryUrl);
-      return registryIndexUrl.href;
+      return registryUrl[registryUrl.length - 1] === '/' ? registryUrl : registryUrl + '/';
     }).map(async url => {
       try {
         return await fetchMetadata(url);

--- a/src/services/registry/devfiles.ts
+++ b/src/services/registry/devfiles.ts
@@ -16,7 +16,7 @@ import axios from 'axios';
 const axiosInstance = axios.create();
 
 function createURL(url: string, baseUrl: string): URL {
-  // todo Remove it after fixing the relative paths for devfile registry https://github.com/eclipse/che/issues/18084
+  // todo Remove it after fixing all source links https://github.com/eclipse/che/issues/19140
   if (/^\/(\w+)/.test(url)) {
     return new URL(`.${url}`, baseUrl);
   }

--- a/src/services/registry/devfiles.ts
+++ b/src/services/registry/devfiles.ts
@@ -16,10 +16,12 @@ import axios from 'axios';
 const axiosInstance = axios.create();
 
 function createURL(url: string, baseUrl: string): URL {
+
   // todo Remove it after fixing all source links https://github.com/eclipse/che/issues/19140
   if (/^\/(\w+)/.test(url)) {
     return new URL(`.${url}`, baseUrl);
   }
+
   return new URL(url, baseUrl);
 }
 


### PR DESCRIPTION
### What does this PR do?
Fix URIs for devfile icon and devfile self-link in single-host mode.

### How to test it?
Deploy Single Host Che with the following CheCluster patch
```yaml
# save the content to /tmp/che-custom-che-server.yaml and execute the following:
# chectl server:deploy --installer=operator --platform=minikube --che-operator-cr-patch-yaml=/tmp/che-custom-che-server.yaml
spec:
  k8s: 
    singleHostExposureType: 'gateway'
  server:
    serverExposureStrategy: single-host
```

### What issues does this PR fix or reference?
fixes https://github.com/eclipse/che/issues/18084
