### PR TITLE
increase the max length of the password allowed for a container regis…

### DIFF
--- a/src/pages/UserPreferences/RegistryPassword/__tests__/index.spec.tsx
+++ b/src/pages/UserPreferences/RegistryPassword/__tests__/index.spec.tsx
@@ -98,8 +98,8 @@ describe('Registry Password Input', () => {
 
       const input = screen.getByTestId('registry-password-input');
 
-      const message = 'The password is too long. The maximum length is 100 characters.';
-      const allowedPassword = 'a'.repeat(100);
+      const message = 'The password is too long. The maximum length is 10000 characters.';
+      const allowedPassword = 'a'.repeat(10000);
       let label: HTMLElement | null;
 
       userEvent.clear(input);
@@ -108,7 +108,7 @@ describe('Registry Password Input', () => {
       label = screen.queryByText(message);
       expect(label).toBeFalsy();
 
-      const disallowedPassword = 'a'.repeat(101);
+      const disallowedPassword = 'a'.repeat(10001);
 
       userEvent.clear(input);
       userEvent.type(input, disallowedPassword);

--- a/src/pages/UserPreferences/RegistryPassword/index.tsx
+++ b/src/pages/UserPreferences/RegistryPassword/index.tsx
@@ -14,7 +14,7 @@ import React from 'react';
 import { EyeIcon, EyeSlashIcon, ExclamationCircleIcon } from '@patternfly/react-icons';
 import { Button, FormGroup, InputGroupText, TextInput, ValidatedOptions } from '@patternfly/react-core';
 
-const MAX_LENGTH = 100;
+const MAX_LENGTH = 10000;
 const ERROR_REQUIRED_VALUE = 'A value is required.';
 const ERROR_MAX_LENGTH = `The password is too long. The maximum length is ${MAX_LENGTH} characters.`;
 


### PR DESCRIPTION
…try. This allows for a container registry that uses json keys

kind/usability

### What does this PR do?
Increase the max password length for a container registry. Some container registries don't use passwords but use keys that can be much longer than 100. This pr hopes to make it easier to use these type of container registries. 

This was change was proposed before in the old dashboard.

https://github.com/eclipse/che/issues/5678
https://cloud.google.com/container-registry/docs/advanced-authentication
https://github.com/eclipse/che/pull/13569/files

I'm not sure if the logic should be removed like the previous change or if the max length should be made very high. I proposed a high number to make the change small. If others would like it removed that would also be good. 
