### PR TITLE
Remove duplicating product name from version title

### DIFF
--- a/src/Layout/Header/Tools/__tests__/about-modal.spec.tsx
+++ b/src/Layout/Header/Tools/__tests__/about-modal.spec.tsx
@@ -11,7 +11,7 @@
  */
 
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { AboutModal } from '../about-modal';
 
 jest.mock('../../../../../node_modules/detect-browser/index.js', () => {
@@ -55,7 +55,7 @@ describe('About modal', () => {
     expect(getByText('test-user')).not.toBeNull();
   });
 
-  fit('should display product version', () => {
+  it('should display product version', () => {
     const { getByText } = render(component);
     expect(getByText('Version')).not.toBeNull();
     expect(getByText('0.0.1')).not.toBeNull();

--- a/src/Layout/Header/Tools/__tests__/about-modal.spec.tsx
+++ b/src/Layout/Header/Tools/__tests__/about-modal.spec.tsx
@@ -70,7 +70,7 @@ describe('About modal', () => {
   it('should display browser os', () => {
     const { getByText } = render(component);
     expect(getByText('Browser OS')).not.toBeNull();
-    expect(getByText('Linux')).not.toBeNull();
+    expect(getByText(/linux/i)).not.toBeNull();
   });
 
   it('should display browser name', () => {

--- a/src/Layout/Header/Tools/__tests__/about-modal.spec.tsx
+++ b/src/Layout/Header/Tools/__tests__/about-modal.spec.tsx
@@ -57,7 +57,7 @@ describe('About modal', () => {
 
   it('should display product version', () => {
     const { getByText } = render(component);
-    expect(getByText(/Che version/i)).not.toBeNull();
+    expect(getByText(/Version/i)).not.toBeNull();
     expect(getByText(/0.0.1/i)).not.toBeNull();
   });
 

--- a/src/Layout/Header/Tools/__tests__/about-modal.spec.tsx
+++ b/src/Layout/Header/Tools/__tests__/about-modal.spec.tsx
@@ -11,7 +11,7 @@
  */
 
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { AboutModal } from '../about-modal';
 
 jest.mock('../../../../../node_modules/detect-browser/index.js', () => {
@@ -51,31 +51,31 @@ describe('About modal', () => {
 
   it('should display username', () => {
     const { getByText } = render(component);
-    expect(getByText(/username/i)).not.toBeNull();
-    expect(getByText(/test-user/i)).not.toBeNull();
+    expect(getByText('Username')).not.toBeNull();
+    expect(getByText('test-user')).not.toBeNull();
   });
 
-  it('should display product version', () => {
+  fit('should display product version', () => {
     const { getByText } = render(component);
-    expect(getByText(/Version/i)).not.toBeNull();
-    expect(getByText(/0.0.1/i)).not.toBeNull();
+    expect(getByText('Version')).not.toBeNull();
+    expect(getByText('0.0.1')).not.toBeNull();
   });
 
   it('should display browser version', () => {
     const { getByText } = render(component);
-    expect(getByText(/Browser version/i)).not.toBeNull();
-    expect(getByText(/1.0.0/i)).not.toBeNull();
+    expect(getByText('Browser Version')).not.toBeNull();
+    expect(getByText('1.0.0')).not.toBeNull();
   });
 
   it('should display browser os', () => {
     const { getByText } = render(component);
-    expect(getByText(/Browser OS/i)).not.toBeNull();
-    expect(getByText(/Linux/i)).not.toBeNull();
+    expect(getByText('Browser OS')).not.toBeNull();
+    expect(getByText('Linux')).not.toBeNull();
   });
 
   it('should display browser name', () => {
     const { getByText } = render(component);
-    expect(getByText(/Browser Name/i)).not.toBeNull();
+    expect(getByText('Browser Name')).not.toBeNull();
     expect(getByText(/chrome/i)).not.toBeNull();
   });
 });

--- a/src/Layout/Header/Tools/about-modal.tsx
+++ b/src/Layout/Header/Tools/about-modal.tsx
@@ -31,7 +31,6 @@ type AboutModalProps = {
 type AboutModalItemsProps = {
   username: string | undefined;
   productVersion: string | undefined;
-  productName: string | undefined;
   browserVersion: string | null | undefined;
   browserOS: string | null | undefined;
   browserName: string | null | undefined;
@@ -40,7 +39,6 @@ type AboutModalItemsProps = {
 const AboutModalItems: React.FC<AboutModalItemsProps> = (
   props: AboutModalItemsProps
 ) => {
-  const productName = props.productName;
   const productVersion = props.productVersion;
   const username = props.username;
   const browserVersion = props.browserVersion;
@@ -123,7 +121,6 @@ export class AboutModal extends React.PureComponent<AboutModalProps> {
           browserOS={browserOS}
           browserVersion={browserVersion}
           browserName={browserName}
-          productName={productName}
         />
       </PatternflyAboutModal>
     );

--- a/src/Layout/Header/Tools/about-modal.tsx
+++ b/src/Layout/Header/Tools/about-modal.tsx
@@ -52,7 +52,7 @@ const AboutModalItems: React.FC<AboutModalItemsProps> = (
         <TextList component='dl'>
           {productVersion && (
             <>
-              <TextListItem component='dt'>{productName} version</TextListItem>
+              <TextListItem component='dt'>Version</TextListItem>
               <TextListItem component='dd'>
                 <div className='co-select-to-copy'>{productVersion}</div>
               </TextListItem>


### PR DESCRIPTION
### What does this PR do?
Removes duplicating product name from version title.

![Screenshot_20210322_181555](https://user-images.githubusercontent.com/5887312/112022140-aa82e080-8b3a-11eb-89f5-ca3beaa5d25a.png)

### What issues does this PR fix or reference?
It seems to be what Parvathy suggested in https://github.com/eclipse/che/issues/18567#issuecomment-742640132
and it's what Nick suggests in https://issues.redhat.com/browse/CRW-1676


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
