### PR TITLE
Fix apiVersion in ownerReference so that devworkspacetemplates cleaned up

### DIFF
--- a/src/services/workspace-client/devWorkspaceClient.ts
+++ b/src/services/workspace-client/devWorkspaceClient.ts
@@ -13,7 +13,7 @@
 import { inject, injectable } from 'inversify';
 import { convertDevWorkspaceV2ToV1, isDeleting, isWebTerminal } from '../helpers/devworkspace';
 import { WorkspaceClient } from './';
-import { DevWorkspaceClient as DevWorkspaceClientLibrary, IDevWorkspaceApi, IDevWorkspaceDevfile, IDevWorkspace, IDevWorkspaceTemplateApi, IDevWorkspaceTemplate, devWorkspaceApiGroup, devworkspaceSingularSubresource } from '@eclipse-che/devworkspace-client';
+import { DevWorkspaceClient as DevWorkspaceClientLibrary, IDevWorkspaceApi, IDevWorkspaceDevfile, IDevWorkspace, IDevWorkspaceTemplateApi, IDevWorkspaceTemplate, devWorkspaceApiGroup, devworkspaceSingularSubresource, devworkspaceVersion } from '@eclipse-che/devworkspace-client';
 import { DevWorkspaceStatus, WorkspaceStatus } from '../helpers/types';
 import { KeycloakSetupService } from '../keycloak/setup';
 import { delay } from '../helpers/delay';
@@ -93,7 +93,7 @@ export class DevWorkspaceClient extends WorkspaceClient {
       // todo handle error in a proper way
       const pluginName = pluginDevfile.metadata.name.replaceAll(' ', '-').toLowerCase();
       const workspaceId = createdWorkspace.status.workspaceId;
-      const devfileGroupVersion = 'workspace.devfile.io/v1alpha2';
+      const devfileGroupVersion = `${devWorkspaceApiGroup}/${devworkspaceVersion}`;
       const theiaDWT = await this.dwtApi.create(<IDevWorkspaceTemplate>{
         kind: 'DevWorkspaceTemplate',
         apiVersion: devfileGroupVersion,

--- a/src/services/workspace-client/devWorkspaceClient.ts
+++ b/src/services/workspace-client/devWorkspaceClient.ts
@@ -93,15 +93,16 @@ export class DevWorkspaceClient extends WorkspaceClient {
       // todo handle error in a proper way
       const pluginName = pluginDevfile.metadata.name.replaceAll(' ', '-').toLowerCase();
       const workspaceId = createdWorkspace.status.workspaceId;
+      const devfileGroupVersion = 'workspace.devfile.io/v1alpha2';
       const theiaDWT = await this.dwtApi.create(<IDevWorkspaceTemplate>{
         kind: 'DevWorkspaceTemplate',
-        apiVersion: 'workspace.devfile.io/v1alpha2',
+        apiVersion: devfileGroupVersion,
         metadata: {
           name: `${pluginName}-${workspaceId}`,
           namespace,
           ownerReferences: [
             {
-              apiVersion: devWorkspaceApiGroup,
+              apiVersion: devfileGroupVersion,
               kind: devworkspaceSingularSubresource,
               name: createdWorkspace.metadata.name,
               uid: createdWorkspace.metadata.uid


### PR DESCRIPTION
Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
This PR fixes the devworkspacetemplate ownerReference so that it is set correctly

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/19328

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
