### PR TITLE
Enhance error handling for when che workspace routing isn't installed

### DIFF
--- a/src/services/helpers/types.ts
+++ b/src/services/helpers/types.ts
@@ -38,6 +38,7 @@ export enum WorkspaceStatus {
 
 export enum DevWorkspaceStatus {
   FAILED = 1,
+  RUNNING = 2
 }
 
 export type GettingStartedTab = 'get-started'

--- a/src/services/workspace-client/devWorkspaceClient.ts
+++ b/src/services/workspace-client/devWorkspaceClient.ts
@@ -80,8 +80,6 @@ export class DevWorkspaceClient extends WorkspaceClient {
       throw new Error(`Could not retrieve devworkspace status information from ${workspaceName} in namespace ${namespace}`);
     } else if (workspaceStatus.phase.toUpperCase() === DevWorkspaceStatus[DevWorkspaceStatus.RUNNING] && !workspaceStatus?.ideUrl) {
       throw new Error('Could not retrieve ideUrl for the running workspace');
-    } else if (workspaceStatus.message === 'Waiting for workspace routing objects') {
-      throw new Error(workspaceStatus.message);
     }
     return convertDevWorkspaceV2ToV1(workspace);
   }

--- a/src/services/workspace-client/devWorkspaceClient.ts
+++ b/src/services/workspace-client/devWorkspaceClient.ts
@@ -75,8 +75,13 @@ export class DevWorkspaceClient extends WorkspaceClient {
       await delay();
     }
     this.checkForDevWorkspaceError(workspace);
-    if (!workspace.status || !workspace.status.phase || !workspace.status.ideUrl) {
+    const workspaceStatus = workspace.status;
+    if (!workspaceStatus || !workspaceStatus.phase) {
       throw new Error(`Could not retrieve devworkspace status information from ${workspaceName} in namespace ${namespace}`);
+    } else if (workspaceStatus.phase.toUpperCase() === DevWorkspaceStatus[DevWorkspaceStatus.RUNNING] && !workspaceStatus?.ideUrl) {
+      throw new Error('Could not retrieve ideUrl for the running workspace');
+    } else if (workspaceStatus.message === 'Waiting for workspace routing objects') {
+      throw new Error(workspaceStatus.message);
     }
     return convertDevWorkspaceV2ToV1(workspace);
   }


### PR DESCRIPTION
Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
This PR makes it so that a devworkspace will error when a devworkspace is stuck on `'Waiting for workspace routing objects'`. This is because when the devworkspace che controller isn't installed the devworkspace-controller loops and never get's past the starting state. It's not ideal to depend on the exact message from the devworkspace controller but I don't really see any other way.

To test:
```
echo "spec:
  devWorkspace:
    enable: true" > devworkspace-config.yaml
chectl server:deploy --installer=operator --platform=openshift --che-operator-cr-patch-yaml=devworkspace-config.yaml
```
then scale down both deployments in the devworkspace-che namespace and then create a devworkspace with:
```
#{CHE_URL}/#/load-factory/?url=https://github.com/l0rd/spring-petclinic/tree/devfile2
```

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/19325

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
