### PR TITLE
Fix Get Started page title

### DIFF
--- a/src/Layout/Navigation/MainList.tsx
+++ b/src/Layout/Navigation/MainList.tsx
@@ -24,7 +24,7 @@ import { ROUTE } from '../../route.enum';
 import styles from './index.module.css';
 
 const items: NavigationItemObject[] = [
-  { to: ROUTE.GET_STARTED, label: 'Get Started Page', icon: <PlusIcon className={styles.mainItemIcon} /> },
+  { to: ROUTE.GET_STARTED, label: 'Get Started', icon: <PlusIcon className={styles.mainItemIcon} /> },
   { to: ROUTE.WORKSPACES, label: 'Workspaces', icon: <CubesIcon className={styles.mainItemIcon} /> },
 ];
 

--- a/src/Layout/Navigation/__tests__/MainList.spec.tsx
+++ b/src/Layout/Navigation/__tests__/MainList.spec.tsx
@@ -44,7 +44,7 @@ describe('Navigation Main List', () => {
 
     const navLinks = screen.getAllByRole('link');
 
-    expect(navLinks[0]).toHaveTextContent('Get Started Page');
+    expect(navLinks[0]).toHaveTextContent('Get Started');
     expect(navLinks[1]).toHaveTextContent('Workspaces');
   });
 


### PR DESCRIPTION
### What does this PR do?
This PR removes Page word from Get Started title, it's what was recommended initially
![Screenshot_20210401_112402](https://user-images.githubusercontent.com/5887312/113265496-de010000-92dc-11eb-96ae-1109b5e9ad39.png)


### What issues does this PR fix or reference?
Related PR that changes e2e tests https://github.com/eclipse/che/pull/19433

Fixes https://github.com/eclipse/che/issues/19412

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
