### PR TITLE
Finalize workspace to devworkspace renaming

### DIFF
--- a/.deps/EXCLUDED/prod.md
+++ b/.deps/EXCLUDED/prod.md
@@ -4,6 +4,6 @@ This file lists dependencies that do not need CQs or auto-detection does not wor
 | `che-dashboard-e2e@1.0.0` | N/A |
 | `@eclipse-che/api@7.18.1` | N/A |
 | `@eclipse-che/workspace-client@0.0.1-1615287725` | N/A |
-| `@eclipse-che/devworkspace-client@0.0.1-1614934724` | N/A |
+| `@eclipse-che/devworkspace-client@0.0.1-1617871695` | N/A |
 | `@patternfly/react-core@4.84.4` | [CQ22936](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=22936) |
 | `prettier@2.2.1` | [CQ23020](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=23020) |

--- a/.deps/prod.md
+++ b/.deps/prod.md
@@ -4,7 +4,7 @@
 | --- | --- | --- |
 | [`@babel/runtime@7.10.2`](https://github.com/babel/babel.git) | MIT | clearlydefined |
 | `@eclipse-che/api@7.18.1` | EPL-2.0 | N/A |
-| [`@eclipse-che/devworkspace-client@0.0.1-1614934724`](https://github.com/che-incubator/devworkspace-client) | EPL-2.0 | N/A |
+| [`@eclipse-che/devworkspace-client@0.0.1-1617871695`](https://github.com/che-incubator/devworkspace-client) | EPL-2.0 | N/A |
 | [`@eclipse-che/workspace-client@0.0.1-1615287725`](https://github.com/eclipse/che-workspace-client) | EPL-2.0 | N/A |
 | [`@kubernetes/client-node@0.14.0`](https://github.com/kubernetes-client/javascript.git) | Apache-2.0 | clearlydefined |
 | [`@panva/asn1.js@1.0.0`](https://github.com/panva/asn1.js.git) | MIT | clearlydefined |
@@ -129,7 +129,7 @@
 | [`http-parser-js@0.5.2`](git://github.com/creationix/http-parser-js.git) | MIT | clearlydefined |
 | [`http-proxy-agent@2.1.0`](git://github.com/TooTallNate/node-http-proxy-agent.git) | MIT | [CQ18717](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=18717) |
 | [`http-signature@1.2.0`](git://github.com/joyent/node-http-signature.git) | MIT | [CQ16925](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=16925) |
-| [`http2-wrapper@1.0.0-beta.5.2`](git+https://github.com/szmarczak/http2-wrapper.git) | MIT | clearlydefined |
+| [`http2-wrapper@1.0.0-beta.5.2`](git+https://github.com/szmarczak/http2-wrapper.git) | MIT | [CQ23110](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=23110) |
 | [`https-proxy-agent@2.2.4`](git://github.com/TooTallNate/node-https-proxy-agent.git) | MIT | [CQ18717](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=18717) |
 | [`indent-string@4.0.0`](https://github.com/sindresorhus/indent-string.git) | MIT | clearlydefined |
 | [`inflight@1.0.6`](https://github.com/npm/inflight.git) | ISC | [CQ16925](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=16925) |
@@ -151,7 +151,7 @@
 | [`isexe@2.0.0`](git+https://github.com/isaacs/isexe.git) | ISC | [CQ17757](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=17757) |
 | [`isomorphic-ws@4.0.1`](git+https://github.com/heineiuo/isomorphic-ws.git) | MIT | clearlydefined |
 | [`isstream@0.1.2`](https://github.com/rvagg/isstream.git) | MIT | [CQ16925](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=16925) |
-| [`jose@2.0.4`](https://github.com/panva/jose.git) | MIT |  |
+| [`jose@2.0.4`](https://github.com/panva/jose.git) | MIT | clearlydefined |
 | [`jquery@3.5.1`](https://github.com/jquery/jquery.git) | MIT | clearlydefined |
 | [`js-tokens@4.0.0`](https://github.com/lydell/js-tokens.git) | MIT | [CQ18717](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=18717) |
 | [`js-yaml@3.14.0`](https://github.com/nodeca/js-yaml.git) | MIT | clearlydefined |

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "licenseCheck:run": "license-tool/run.sh"
   },
   "dependencies": {
-    "@eclipse-che/devworkspace-client": "^0.0.1-1614934724",
+    "@eclipse-che/devworkspace-client": "^0.0.1-1617871695",
     "@eclipse-che/workspace-client": "^0.0.1-1615287725",
     "@patternfly/react-core": "~4.84.4",
     "@patternfly/react-icons": "^4.3.5",

--- a/src/services/helpers/devworkspace.ts
+++ b/src/services/helpers/devworkspace.ts
@@ -27,8 +27,8 @@ export function convertDevWorkspaceV2ToV1(devworkspace: IDevWorkspace): che.Work
     infrastructureNamespace: namespace,
     created: epochCreatedTimestamp.toString(),
   };
-  if (devworkspace.status?.workspaceId) {
-    convertedWorkspace.id = devworkspace.status?.workspaceId;
+  if (devworkspace.status?.devworkspaceId) {
+    convertedWorkspace.id = devworkspace.status?.devworkspaceId;
   }
   let status = devworkspace.status?.phase;
   if (status) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -466,13 +466,15 @@
   resolved "https://registry.yarnpkg.com/@eclipse-che/api/-/api-7.18.1.tgz#1beae9ebe694e4b58d0edfefcde07995ce6cd0b2"
   integrity sha512-KnnnDpnxxK0TBgR0Ux3oOYCvmCv6d4cRA+1j9wiLkaJighCqgCUaxnHWXEfolYbRq1+o/sfsxN+BxRDuF+H8wQ==
 
-"@eclipse-che/devworkspace-client@^0.0.1-1614934724":
-  version "0.0.1-1614934724"
-  resolved "https://registry.yarnpkg.com/@eclipse-che/devworkspace-client/-/devworkspace-client-0.0.1-1614934724.tgz#ca1f2590e0c649d24abdb64b976f7328f1c8b709"
-  integrity sha512-/YC88f/0pjjUH68C8hnnppuQNL+vo1zFbJLHvUpFMLx5uyoI6qOZ/b51uGMZpPqZiGiGpo52ja28fZawE/UsgQ==
+"@eclipse-che/devworkspace-client@^0.0.1-1617871695":
+  version "0.0.1-1617871695"
+  resolved "https://registry.yarnpkg.com/@eclipse-che/devworkspace-client/-/devworkspace-client-0.0.1-1617871695.tgz#1c523db6e192beb9fb6acfd53aed0d11fc6a91f3"
+  integrity sha512-zZXGKyWJW5MzOvUu1nsy535pXd5DuJoV0zg/fhycJfDDipdeYtTQSoHDVy0+xuSkT81PdxAGayP1R/dzHPnWMw==
   dependencies:
     "@kubernetes/client-node" "^0.14.0"
     axios "^0.21.1"
+    inversify "^5.0.5"
+    reflect-metadata "^0.1.13"
 
 "@eclipse-che/workspace-client@^0.0.1-1615287725":
   version "0.0.1-1615287725"
@@ -5421,6 +5423,11 @@ inversify@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/inversify/-/inversify-5.0.1.tgz#500d709b1434896ce5a0d58915c4a4210e34fb6e"
   integrity sha512-Ieh06s48WnEYGcqHepdsJUIJUXpwH5o5vodAX+DK2JA/gjy4EbEcQZxw+uFfzysmKjiLXGYwNG3qDZsKVMcINQ==
+
+inversify@^5.0.5:
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/inversify/-/inversify-5.0.5.tgz#bd1f8e6d8e0f739331acd8ba9bc954635aae0bbf"
+  integrity sha512-60QsfPz8NAU/GZqXu8hJ+BhNf/C/c+Hp0eDc6XMIJTxBiP36AQyyQKpBkOVTLWBFDQWYVHpbbEuIsHu9dLuJDA==
 
 invert-kv@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
### What does this PR do?
This PR finalized workspace to devworkspace renaming.
In addition, it also adapts to newer DevWorkspace Client where Che API is introduced + client is initialized in a different way.

### What issues does this PR fix or reference?
It's done in the scope of https://github.com/devfile/devworkspace-operator/issues/321.

It depends on https://github.com/che-incubator/devworkspace-client/pull/19
:warning: After ^ is merged, dependencies should be updated and it should fix PR checks.

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
