### PR TITLE
Fixed the IDE loading page can't find the target workspace.

### DIFF
--- a/src/pages/GetStarted/index.tsx
+++ b/src/pages/GetStarted/index.tsx
@@ -105,7 +105,7 @@ export class GetStarted extends React.PureComponent<Props, State> {
       throw new Error(e.message);
     }
 
-    const workspaceName = workspace.devfile.metadata.name;
+    const workspaceName = workspace.name;
     this.showAlert({
       key: 'new-workspace-success',
       variant: AlertVariant.success,

--- a/src/store/Workspaces/index.ts
+++ b/src/store/Workspaces/index.ts
@@ -258,7 +258,6 @@ export const actionCreators: ActionCreators = {
     dispatch({ type: 'REQUEST_WORKSPACES' });
     try {
       const state = getState();
-      const param = { attributes, namespace, infrastructureNamespace };
 
       const cheDevworkspaceEnabled = state.cheWorkspaces.settings['che.devworkspaces.enabled'] === 'true';
       if (cheDevworkspaceEnabled && isDevfileV2(devfile)) {
@@ -266,8 +265,7 @@ export const actionCreators: ActionCreators = {
         dispatch({ type: 'ADD_WORKSPACE' });
         return convertWorkspace(devWorkspace);
       } else {
-        const cheWorkspace = await cheWorkspaceClient.restApiClient.create<che.Workspace>(devfile, param);
-
+        const cheWorkspace = await dispatch(CheWorkspacesStore.actionCreators.createWorkspaceFromDevfile(devfile as che.WorkspaceDevfile, namespace, infrastructureNamespace, attributes));
         dispatch({
           type: 'ADD_WORKSPACE',
         });


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

Fixed bug that caused the alert message "Failed to find the target workspace." on the IDE loading page while the workspace was loading successfully.

### What issues does this PR fix or reference?

fixes https://github.com/eclipse/che/issues/19603
